### PR TITLE
Clean up gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,6 @@
 .ipynb_checkpoints/*
 *.mexw64
-Plot.ipynb
-*J_ADOLC.txt
-*J_ADOLC_split.txt
-*J_Autograd.txt
-*J_Ceres.txt
-*J_diffsharpAD.txt
-*J_diffsharpR.txt
-*J_diffsharpRsplit.txt
-*J_diffsharp.txt
-*J_manual.txt
-*J_Tapenade_b.txt
-*J_Tapenade_bv.txt
-*J_Tapenade_dv.txt
-*_times.txt
-autogen_example_gmm_objective_mex_d2_K30.cxx
-# results of experiments (the runtime results are then composed into .mat file which is not ignored)
-*_J_*
-*_times_*
-estimates_backup.mat
+/tmp/
 
 /packages
 
@@ -27,6 +9,7 @@ estimates_backup.mat
 *.user
 *.userosscache
 *.sln.docstates
+.vscode
 
 # Visual C++ cache files
 ipch/
@@ -41,13 +24,11 @@ ipch/
 Debug/
 Release/
 obj/
+*-build/
+build/
 
 # Python
 __pycache__
 *.obj
 *.exe
-ba - Copy.txt
-ba-old.txt
 
-.vscode
-*-build/


### PR DESCRIPTION
Now that output files are moved to ``tmp``, can clean up gitignore.