### PR TITLE
Fix build issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 
 /packages
 
+etc/HunterGate-Root-awf
+
 # User-specific files
 *.suo
 *.user

--- a/ADBench/run-all.ps1
+++ b/ADBench/run-all.ps1
@@ -225,12 +225,7 @@ Class Tool {
 		$cmd = ""
 		$cmdargs = @($dir_in, $dir_out, $fn, $script:nruns_f, $script:nruns_J, $script:time_limit)
 		if ($this.type -eq "bin") {
-			if ($this.name -eq "DiffSharp") {
-				$builddir = ""
-			} else {
-				$builddir = "\$script:buildtype"
-			}
-			$cmd = "$script:bindir\tools\$($this.name)$builddir\Tools-$($this.name)-$objective.exe"
+			$cmd = "$script:bindir\tools\$($this.name)\Tools-$($this.name)-$objective.exe"
 
 		} elseif ($this.type -eq "py" -or $this.type -eq "pybat") {
 			$objective = $objective.ToLower().Replace("-", "_")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,21 @@
 cmake_minimum_required (VERSION 3.6)
 
 # Set build type variable
-#	so RelWithDebInfo is treated as Release
+# so RelWithDebInfo is treated as Release
 if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
-	set(AD_BUILD_TYPE "Debug")
+    set(AD_BUILD_TYPE "Debug")
 else ()
-	set(AD_BUILD_TYPE "Release")
+    set(AD_BUILD_TYPE "Release")
 endif ()
+
+# $<1:> always resolves to empty string, but the fact, that a generator
+# expression is used, forces Visual Studio generator to not create
+# configuration-specific folders for outputs, thus making output paths
+# consistent between different generators.
+# See https://cmake.org/cmake/help/v3.5/prop_tgt/RUNTIME_OUTPUT_DIRECTORY.html#prop_tgt:RUNTIME_OUTPUT_DIRECTORY
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY $<1:>)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY $<1:>)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY $<1:>)
 
 
 set(HUNTER_STATUS_DEBUG OFF)
@@ -17,7 +26,7 @@ set(HUNTER_BUILD_SHARED_LIBS OFF)
 
 # Get HunterGate package manager
 if(NOT DEFINED ENV{HUNTER_ROOT})
-	set(ENV{HUNTER_ROOT} "etc/HunterGate-Root-awf")
+    set(ENV{HUNTER_ROOT} "etc/HunterGate-Root-awf")
     message(STATUS "Setting HUNTER_ROOT to $ENV{HUNTER_ROOT}")
 endif()
 include("etc/HunterGate.cmake")
@@ -25,7 +34,7 @@ include("etc/HunterGate.cmake")
 HunterGate(
     URL "https://github.com/ruslo/hunter/archive/v0.23.177.tar.gz"
     SHA1 "c3d4bf987a1c5f8ce9bb8b2b80bc6c123185cd66"
-	LOCAL
+    LOCAL
 )
 
 # Declare project name

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ endif()
 include("etc/HunterGate.cmake")
 
 HunterGate(
-    URL "https://github.com/ruslo/hunter/archive/v0.23.6.tar.gz"
-    SHA1 "951e8daf57a51708b0e6a00cab342a042db57a2f"
+    URL "https://github.com/ruslo/hunter/archive/v0.23.177.tar.gz"
+    SHA1 "c3d4bf987a1c5f8ce9bb8b2b80bc6c123185cd66"
 	LOCAL
 )
 

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,27 @@
+﻿{
+    "configurations": [
+        {
+            "name": "x64-Release",
+            "generator": "Ninja",
+            "configurationType": "RelWithDebInfo",
+            "buildRoot": "${projectDir}\\build\\${name}",
+            "installRoot": "${projectDir}\\install\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "-v",
+            "ctestCommandArgs": "",
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "variables": []
+        },
+        {
+            "name": "x64-Debug",
+            "generator": "Ninja",
+            "configurationType": "Debug",
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "buildRoot": "${projectDir}\\build\\${name}",
+            "installRoot": "${projectDir}\\install\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "-v",
+            "ctestCommandArgs": ""
+        }
+    ]
+}

--- a/etc/HunterGate.cmake
+++ b/etc/HunterGate.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2018, Ruslan Baratov
+# Copyright (c) 2013-2019, Ruslan Baratov
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -60,7 +60,7 @@ option(HUNTER_STATUS_PRINT "Print working status" ON)
 option(HUNTER_STATUS_DEBUG "Print a lot info" OFF)
 option(HUNTER_TLS_VERIFY "Enable/disable TLS certificate checking on downloads" ON)
 
-set(HUNTER_WIKI "https://github.com/ruslo/hunter/wiki")
+set(HUNTER_ERROR_PAGE "https://docs.hunter.sh/en/latest/reference/errors")
 
 function(hunter_gate_status_print)
   if(HUNTER_STATUS_PRINT OR HUNTER_STATUS_DEBUG)
@@ -79,9 +79,9 @@ function(hunter_gate_status_debug)
   endif()
 endfunction()
 
-function(hunter_gate_wiki wiki_page)
-  message("------------------------------ WIKI -------------------------------")
-  message("    ${HUNTER_WIKI}/${wiki_page}")
+function(hunter_gate_error_page error_page)
+  message("------------------------------ ERROR ------------------------------")
+  message("    ${HUNTER_ERROR_PAGE}/${error_page}.html")
   message("-------------------------------------------------------------------")
   message("")
   message(FATAL_ERROR "")
@@ -94,14 +94,13 @@ function(hunter_gate_internal_error)
   endforeach()
   message("[hunter ** INTERNAL **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
   message("")
-  hunter_gate_wiki("error.internal")
+  hunter_gate_error_page("error.internal")
 endfunction()
 
 function(hunter_gate_fatal_error)
-  cmake_parse_arguments(hunter "" "WIKI" "" "${ARGV}")
-  string(COMPARE EQUAL "${hunter_WIKI}" "" have_no_wiki)
-  if(have_no_wiki)
-    hunter_gate_internal_error("Expected wiki")
+  cmake_parse_arguments(hunter "" "ERROR_PAGE" "" "${ARGV}")
+  if("${hunter_ERROR_PAGE}" STREQUAL "")
+    hunter_gate_internal_error("Expected ERROR_PAGE")
   endif()
   message("")
   foreach(x ${hunter_UNPARSED_ARGUMENTS})
@@ -109,11 +108,11 @@ function(hunter_gate_fatal_error)
   endforeach()
   message("[hunter ** FATAL ERROR **] [Directory:${CMAKE_CURRENT_LIST_DIR}]")
   message("")
-  hunter_gate_wiki("${hunter_WIKI}")
+  hunter_gate_error_page("${hunter_ERROR_PAGE}")
 endfunction()
 
 function(hunter_gate_user_error)
-  hunter_gate_fatal_error(${ARGV} WIKI "error.incorrect.input.data")
+  hunter_gate_fatal_error(${ARGV} ERROR_PAGE "error.incorrect.input.data")
 endfunction()
 
 function(hunter_gate_self root version sha1 result)
@@ -134,14 +133,10 @@ function(hunter_gate_self root version sha1 result)
 
   string(SUBSTRING "${sha1}" 0 7 archive_id)
 
-  if(EXISTS "${root}/cmake/Hunter")
-    set(hunter_self "${root}")
-  else()
-    set(
-        hunter_self
-        "${root}/_Base/Download/Hunter/${version}/${archive_id}/Unpacked"
-    )
-  endif()
+  set(
+      hunter_self
+      "${root}/_Base/Download/Hunter/${version}/${archive_id}/Unpacked"
+  )
 
   set("${result}" "${hunter_self}" PARENT_SCOPE)
 endfunction()
@@ -195,7 +190,7 @@ function(hunter_gate_detect_root)
 
   hunter_gate_fatal_error(
       "Can't detect HUNTER_ROOT"
-      WIKI "error.detect.hunter.root"
+      ERROR_PAGE "error.detect.hunter.root"
   )
 endfunction()
 
@@ -214,7 +209,7 @@ function(hunter_gate_download dir)
         "Settings:"
         "  HUNTER_ROOT: ${HUNTER_GATE_ROOT}"
         "  HUNTER_SHA1: ${HUNTER_GATE_SHA1}"
-        WIKI "error.run.install"
+        ERROR_PAGE "error.run.install"
     )
   endif()
   string(COMPARE EQUAL "${dir}" "" is_bad)
@@ -323,7 +318,11 @@ function(hunter_gate_download dir)
   )
 
   if(NOT download_result EQUAL 0)
-    hunter_gate_internal_error("Configure project failed")
+    hunter_gate_internal_error(
+        "Configure project failed."
+        "To reproduce the error run: ${CMAKE_COMMAND} -H${dir} -B${build_dir} -G${CMAKE_GENERATOR} ${toolchain_arg} ${make_arg}"
+        "In directory ${dir}"
+    )
   endif()
 
   hunter_gate_status_print(
@@ -396,7 +395,7 @@ macro(HunterGate)
       hunter_gate_fatal_error(
           "Please set HunterGate *before* 'project' command. "
           "Detected project: ${PROJECT_NAME}"
-          WIKI "error.huntergate.before.project"
+          ERROR_PAGE "error.huntergate.before.project"
       )
     endif()
 
@@ -466,7 +465,7 @@ macro(HunterGate)
             "HUNTER_ROOT (${HUNTER_GATE_ROOT}) contains spaces."
             "Set HUNTER_ALLOW_SPACES_IN_PATH=ON to skip this error"
             "(Use at your own risk!)"
-            WIKI "error.spaces.in.hunter.root"
+            ERROR_PAGE "error.spaces.in.hunter.root"
         )
       endif()
     endif()
@@ -491,44 +490,37 @@ macro(HunterGate)
     )
 
     set(_master_location "${_hunter_self}/cmake/Hunter")
-    if(EXISTS "${HUNTER_GATE_ROOT}/cmake/Hunter")
-      # Hunter downloaded manually (e.g. by 'git clone')
-      set(_unused "xxxxxxxxxx")
-      set(HUNTER_GATE_SHA1 "${_unused}")
-      set(HUNTER_GATE_VERSION "${_unused}")
-    else()
-      get_filename_component(_archive_id_location "${_hunter_self}/.." ABSOLUTE)
-      set(_done_location "${_archive_id_location}/DONE")
-      set(_sha1_location "${_archive_id_location}/SHA1")
+    get_filename_component(_archive_id_location "${_hunter_self}/.." ABSOLUTE)
+    set(_done_location "${_archive_id_location}/DONE")
+    set(_sha1_location "${_archive_id_location}/SHA1")
 
-      # Check Hunter already downloaded by HunterGate
-      if(NOT EXISTS "${_done_location}")
-        hunter_gate_download("${_archive_id_location}")
-      endif()
+    # Check Hunter already downloaded by HunterGate
+    if(NOT EXISTS "${_done_location}")
+      hunter_gate_download("${_archive_id_location}")
+    endif()
 
-      if(NOT EXISTS "${_done_location}")
-        hunter_gate_internal_error("hunter_gate_download failed")
-      endif()
+    if(NOT EXISTS "${_done_location}")
+      hunter_gate_internal_error("hunter_gate_download failed")
+    endif()
 
-      if(NOT EXISTS "${_sha1_location}")
-        hunter_gate_internal_error("${_sha1_location} not found")
-      endif()
-      file(READ "${_sha1_location}" _sha1_value)
-      string(COMPARE EQUAL "${_sha1_value}" "${HUNTER_GATE_SHA1}" _is_equal)
-      if(NOT _is_equal)
-        hunter_gate_internal_error(
-            "Short SHA1 collision:"
-            "  ${_sha1_value} (from ${_sha1_location})"
-            "  ${HUNTER_GATE_SHA1} (HunterGate)"
-        )
-      endif()
-      if(NOT EXISTS "${_master_location}")
-        hunter_gate_user_error(
-            "Master file not found:"
-            "  ${_master_location}"
-            "try to update Hunter/HunterGate"
-        )
-      endif()
+    if(NOT EXISTS "${_sha1_location}")
+      hunter_gate_internal_error("${_sha1_location} not found")
+    endif()
+    file(READ "${_sha1_location}" _sha1_value)
+    string(COMPARE EQUAL "${_sha1_value}" "${HUNTER_GATE_SHA1}" _is_equal)
+    if(NOT _is_equal)
+      hunter_gate_internal_error(
+          "Short SHA1 collision:"
+          "  ${_sha1_value} (from ${_sha1_location})"
+          "  ${HUNTER_GATE_SHA1} (HunterGate)"
+      )
+    endif()
+    if(NOT EXISTS "${_master_location}")
+      hunter_gate_user_error(
+          "Master file not found:"
+          "  ${_master_location}"
+          "try to update Hunter/HunterGate"
+      )
     endif()
     include("${_master_location}")
     set_property(GLOBAL PROPERTY HUNTER_GATE_DONE YES)


### PR DESCRIPTION
This PR fixes 2 problems:
1. CMake crashes in VS 2017/2019
2. Inconsistent output paths between generators - #19 https://github.com/awf/ADBench/issues/26#issuecomment-496293313

Solutions:
1. Update HunterGate (after that VS 2019 consistently works w/o errors on at least 2 machines, before it consistently crashed)
2. Set 
CMAKE_*_OUTPUT_DIRECTORY to 
generator expressions resolving to empty values in order 
to avoid creation of configuration related folders by multi-config generators such as `Visual Studio X X` https://cmake.org/cmake/help/v3.5/prop_tgt/RUNTIME_OUTPUT_DIRECTORY.html#prop_tgt:RUNTIME_OUTPUT_DIRECTORY

I also added CMakeSettings.json with sensible default config that puts CMakeCache into a folder nearby and makes x64-Release the default configuration for Visual Studio.