### PR TITLE
Use proper casing when writing timing files.

### DIFF
--- a/ADBench/run-all.ps1
+++ b/ADBench/run-all.ps1
@@ -218,9 +218,9 @@ Class Tool {
 
 	# Run a single test
 	[void] run ([string]$objective, [string]$dir_in, [string]$dir_out, [string]$fn) {
-		if ($objective.contains("Eigen")) { $out_name = "$($this.name.ToLower())_eigen" }
-		elseif ($objective.contains("Light")) { $out_name = "$($this.name.ToLower())_light" }
-		elseif ($objective.endswith("SPLIT")) { $out_name = "$($this.name)_split" }
+		if ($objective.contains("Eigen")) { $out_name = "$($this.name)_Eigen" }
+		elseif ($objective.contains("Light")) { $out_name = "$($this.name)_Light" }
+		elseif ($objective.endswith("SPLIT")) { $out_name = "$($this.name)_SPLIT" }
 		else { $out_name = $this.name }
 		$output_file = "${dir_out}${fn}_times_${out_name}.txt"
 		if (!$script:repeat -and (Test-Path $output_file)) {

--- a/ADBench/run-all.ps1
+++ b/ADBench/run-all.ps1
@@ -356,7 +356,7 @@ Class Tool {
 			foreach ($c in [Tool]::lstm_c_vals) {
 				Write-Host "      c=$c"
 
-				$this.run("lstm", [Tool]::lstm_dir_in, $dir_out, "lstm_l${l}_c$c")
+				$this.run("LSTM", [Tool]::lstm_dir_in, $dir_out, "lstm_l${l}_c$c")
 			}
 		}
 	}

--- a/tools/Finite/main.cpp
+++ b/tools/Finite/main.cpp
@@ -238,9 +238,9 @@ void test_hand(const string& model_dir, const string& fn_in, const string& fn_ou
 	});
 
 #ifdef DO_EIGEN
-	string name = "Finite_eigen";
+	string name = "Finite_Eigen";
 #else
-	string name = "Finite_light";
+	string name = "Finite_Light";
 #endif
 
 	write_J(fn_out + "_J_" + name + ".txt", (int)err.size(), (int)theta.size(), &J[0]);
@@ -280,9 +280,9 @@ void test_hand(const string& model_dir, const string& fn_in, const string& fn_ou
 	});
 
 #ifdef DO_EIGEN
-	string name = "Finite_eigen";
+	string name = "Finite_Eigen";
 #else
-	string name = "Finite_light";
+	string name = "Finite_Light";
 #endif
 
 	write_J(fn_out + "_J_" + name + ".txt", (int)err.size(), 2+(int)theta.size(), &J[0]);

--- a/tools/Manual/main.cpp
+++ b/tools/Manual/main.cpp
@@ -70,13 +70,13 @@ void test_gmm(const string& fn_in, const string& fn_out,
   cout << "err: " << err << endl;
 
 #ifdef DO_CPP
-  string name("manual");
+  string name("Manual");
 #elif defined DO_EIGEN
-  string name("manual_eigen");
+  string name("Manual_Eigen");
 #elif defined DO_EIGEN_VECTOR
-  string name("manual_eigen_vector");
+  string name("Manual_Eigen_Vector");
 #else
-  string name("manual");
+  string name("Manual");
 #endif
   write_J(fn_out + "_J_" + name + ".txt", Jrows, Jcols, J.data());
   //write_times(tf, tJ);
@@ -145,9 +145,9 @@ void test_ba(const string& fn_in, const string& fn_out,
   });
 
 #ifdef DO_EIGEN
-  string name("manual_eigen");
+  string name("Manual_Eigen");
 #else
-  string name("manual");
+  string name("Manual");
 #endif
   write_J_sparse(fn_out + "_J_" + name + ".txt", J);
   write_times(tf, tJ);
@@ -181,9 +181,9 @@ void test_hand(const string& model_dir, const string& fn_in, const string& fn_ou
   });
 
 #ifdef DO_EIGEN
-  string name = "manual_eigen";
+  string name = "Manual_Eigen";
 #else
-  string name = "manual_light";
+  string name = "Manual_Light";
 #endif
 
   write_J(fn_out + "_J_" + name + ".txt", (int)err.size(), (int)theta.size(), &J[0]);
@@ -216,9 +216,9 @@ void test_hand(const string& model_dir, const string& fn_in, const string& fn_ou
   });
 
 #ifdef DO_EIGEN
-  string name = "manual_eigen";
+  string name = "Manual_Eigen";
 #else
-  string name = "manual_light";
+  string name = "Manual_Light";
 #endif
 
   write_J(fn_out + "_J_" + name + ".txt", (int)err.size(), 2+(int)theta.size(), &J[0]);


### PR DESCRIPTION
Previously, the C++ implementations (at least some of them) would write output files with a different casing than expected by the run-all.ps1 script.  This doesn't matter on case-insensitive file systems, but it does matter on Linux.

I think it's a bit inconsistent that the casing of "manual" depends on whether we are using Eigen or not, but run-all.ps1 specifically lowercases the implementation name in these cases, so I guess it's intentional.