### PR TITLE
Make _scandir_rec not choke on directories that contain non-folders.

### DIFF
--- a/ADBench/utils.py
+++ b/ADBench/utils.py
@@ -23,18 +23,27 @@ def _set_rec(obj, keys, value, append=False):
         return obj
 
 
-# Recursively scan a directory
-def _scandir_rec(folder, depth=0):
+# Recursively scan a directory for files
+#
+# For a directory structure like
+#
+#   a/b1/file1
+#   a/b1/file2
+#   a/b2 (an empty directory)
+#   a/b3/c/file3
+#
+# _scandir_rec("a") yields
+#
+#   ["b1", "file1"]
+#   ["b1", "file2"]
+#   ["b3", "c", "file3"]
+def _scandir_rec(folder):
     folder = folder.rstrip("/") + "/"
-    if len(os.listdir(folder)) > 0 and os.path.isdir(folder + os.listdir(folder)[0]):
-        results = []
-        for fn in os.listdir(folder):
-            results += [[fn] + file_name for file_name in _scandir_rec(folder + fn, depth + 1)]
-    else:
-        results = [[fn] for fn in os.listdir(folder)]
-    # results = [[folder.split("/")[-2]] + fn for fn in results]
-    return results
-
+    for fn in os.listdir(folder):
+        if os.path.isdir(folder + fn):
+            yield from ([fn] + file_name for file_name in _scandir_rec(folder + fn))
+        else:
+            yield [fn]
 
 # Recursively make directories for file/directory
 def _mkdir_if_none(path):


### PR DESCRIPTION
Without this change, I get the following error when running `plot_graphs.py`:

```
$ python3 ADBench/plot_graphs.py --save plot
Output directory is: /home/athas/repos/ADBench/tmp/graphs

Traceback (most recent call last):
  File "ADBench/plot_graphs.py", line 46, in <module>
    all_files = [path for path in utils._scandir_rec(in_dir) if "times" in path[-1]]
  File "/home/athas/repos/ADBench/ADBench/utils.py", line 32, in _scandir_rec
    results += [[fn] + file_name for file_name in _scandir_rec(folder + fn, depth + 1)]
  File "/home/athas/repos/ADBench/ADBench/utils.py", line 32, in _scandir_rec
    results += [[fn] + file_name for file_name in _scandir_rec(folder + fn, depth + 1)]
  File "/home/athas/repos/ADBench/ADBench/utils.py", line 29, in _scandir_rec
    if len(os.listdir(folder)) > 0 and os.path.isdir(folder + os.listdir(folder)[0]):
NotADirectoryError: [Errno 20] Not a directory: '/home/athas/repos/ADBench/tmp/graphs/graphs_index.json/'
```

I still don't understand the logic in `_scandir_rec`, which makes decisions based on whether the first element of `os.listdir(folder)` is a directory.  As far as I know, the order of that list is arbitrary.  This patch should at least make it slightly more robust.