### PR TITLE
Tests of corresponding methodology and c++ runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,10 @@ add_subdirectory ("tools")
 option(ENABLE_TESTS "Enable tests" ON)
 
 if (${ENABLE_TESTS})
-    # Get gtest package
+    # Get gtest and gmock packages
     hunter_add_package(GTest)
-    find_package(GTest CONFIG REQUIRED)
+	
+	find_package (GTest CONFIG REQUIRED)
     find_package(GMock CONFIG REQUIRED)
 
     if(NOT EXISTS "${GTest_LICENSES}")

--- a/src/cpp/runner/Benchmark.h
+++ b/src/cpp/runner/Benchmark.h
@@ -85,7 +85,7 @@ duration<double> measure_shortest_time(const duration<double> minimum_measurable
 {
     auto find_repeats_result = find_repeats_for_minimum_measurable_time(minimum_measurable_time, test, func);
 
-    if (find_repeats_result == measurable_time_not_achieved)
+    if (find_repeats_result.repeats == measurable_time_not_achieved)
     {
         throw exception("It was not possible to reach the number of repeats sufficient to achieve the minimum measurable time.");
     }

--- a/src/cpp/runner/Benchmark.h
+++ b/src/cpp/runner/Benchmark.h
@@ -42,7 +42,7 @@ static constexpr auto measurable_time_not_achieved{ -1 };
 
 template<class Input, class Output>
 auto find_repeats_for_minimum_measurable_time(const duration<double> minimum_measurable_time,
-                                              std::unique_ptr<ITest<Input, Output>>& test,
+                                              const std::unique_ptr<ITest<Input, Output>>& test,
                                               const test_member_function<Input, Output> func)
 {
     auto total_time = duration<double>(0s);

--- a/src/cpp/runner/Benchmark.h
+++ b/src/cpp/runner/Benchmark.h
@@ -28,7 +28,8 @@ using test_member_function = void (ITest<Input, Output>::*) (int);
 
 //This function calls a member of ITest class passing 1 int argument.
 template <class Input, class Output>
-void call_member_function(std::unique_ptr<ITest<Input, Output>>& ptr_to_object, const test_member_function<Input, Output> ptr_to_member, const int arg1) {
+void call_member_function(std::unique_ptr<ITest<Input, Output>>& ptr_to_object,
+                          const test_member_function<Input, Output> ptr_to_member, const int arg1) {
     (*(ptr_to_object).*(ptr_to_member))(arg1);
 }
 
@@ -37,16 +38,19 @@ void call_member_function(std::unique_ptr<ITest<Input, Output>>& ptr_to_object, 
 template<class Input, class Output>
 unique_ptr<ITest<Input, Output>> get_test(const ModuleLoader& module_loader) = delete;
 
+static constexpr auto measurable_time_not_achieved{ -1 };
+
 template<class Input, class Output>
 auto find_repeats_for_minimum_measurable_time(const duration<double> minimum_measurable_time,
-    std::unique_ptr<ITest<Input, Output>>& test,
-    const test_member_function<Input, Output> func)
+                                              std::unique_ptr<ITest<Input, Output>>& test,
+                                              const test_member_function<Input, Output> func)
 {
     auto total_time = duration<double>(0s);
     auto min_sample = duration<double>(std::numeric_limits<double>::max());
 
     auto repeats = 1;
-    while (repeats < (1 << 30))
+    constexpr auto max_possible_power_of_two = (std::numeric_limits<decltype(repeats)>::max() >> 1) + 1;
+    do
     {
         auto t1 = high_resolution_clock::now();
         call_member_function(test, func, repeats);
@@ -60,18 +64,31 @@ auto find_repeats_for_minimum_measurable_time(const duration<double> minimum_mea
             total_time += current_run_time;
             break;
         }
+        //The next iteration will overflow a loop counter that's why we recognize that we cannot reach the minimum measurable time.
+        if (repeats == max_possible_power_of_two)
+        {
+            repeats = measurable_time_not_achieved;
+            break;
+        }
         repeats *= 2;
-    }
+    } while (repeats <= max_possible_power_of_two);
 
     struct result { int repeats; duration<double> sample; duration<double> total_time; };
-    return result { repeats, min_sample, total_time };
+    return result{ repeats, min_sample, total_time };
 }
 
 //Measures time according to the documentation.
 template<class Input, class Output>
-duration<double> measure_shortest_time(const duration<double> minimum_measurable_time, const int nruns, const duration<double> time_limit, std::unique_ptr<ITest<Input, Output>>& test, const test_member_function<Input, Output> func)
+duration<double> measure_shortest_time(const duration<double> minimum_measurable_time, const int nruns,
+                                       const duration<double> time_limit, std::unique_ptr<ITest<Input, Output>>& test,
+                                       const test_member_function<Input, Output> func)
 {
     auto find_repeats_result = find_repeats_for_minimum_measurable_time(minimum_measurable_time, test, func);
+
+    if (find_repeats_result == measurable_time_not_achieved)
+    {
+        throw exception("It was not possible to reach the number of repeats sufficient to achieve the minimum measurable time.");
+    }
 
     auto repeats = find_repeats_result.repeats;
     auto min_sample = find_repeats_result.sample;
@@ -100,7 +117,7 @@ std::string filepath_to_basename(const std::string& filepath);
 //Performs the entire benchmark process according to the documentation
 template<class Input, class Output>
 void run_benchmark(const char* const module_path, const std::string& input_filepath, const std::string& output_prefix, const duration<double> minimum_measurable_time, const int nruns_F, const int nruns_J,
-    const duration<double> time_limit, const bool replicate_point) {
+                   const duration<double> time_limit, const bool replicate_point) {
 
     const ModuleLoader module_loader(module_path);
     auto test = get_test<Input, Output>(module_loader);

--- a/src/cpp/runner/Benchmark.h
+++ b/src/cpp/runner/Benchmark.h
@@ -49,7 +49,8 @@ double measure_shortest_time(const double minimum_measurable_time, const int nru
         auto t1 = high_resolution_clock::now();
         call_member_function(test, func, repeats);
         auto t2 = high_resolution_clock::now();
-        const auto current_run_time = duration_cast<duration<double>>(t2 - t1).count();
+        //Time in seconds
+        const auto current_run_time = duration_cast<duration<double>>(t2 - t1).count(); 
         if (current_run_time > minimum_measurable_time)
         {
             min_sample = std::min(min_sample, current_run_time / repeats);
@@ -64,6 +65,7 @@ double measure_shortest_time(const double minimum_measurable_time, const int nru
         auto t1 = high_resolution_clock::now();
         call_member_function(test, func, repeats);
         auto t2 = high_resolution_clock::now();
+        //Time in seconds
         const auto current_run_time = duration_cast<duration<double>>(t2 - t1).count();
         min_sample = std::min(min_sample, current_run_time / repeats);
         total_time += current_run_time;

--- a/src/cpp/runner/Benchmark.h
+++ b/src/cpp/runner/Benchmark.h
@@ -9,7 +9,6 @@
 using std::chrono::duration;
 using std::chrono::duration_cast;
 using std::chrono::high_resolution_clock;
-using std::chrono::seconds;
 
 /*
  * General logic of the benchmark described in this file.

--- a/src/cpp/runner/main.cpp
+++ b/src/cpp/runner/main.cpp
@@ -23,10 +23,10 @@ int main(const int argc, const char* argv[])
         const auto module_path = argv[2];
         const string input_filepath(argv[3]);
         const string output_prefix(argv[4]);
-        const auto minimum_measurable_time = std::stod(argv[5]);
+        const auto minimum_measurable_time = duration<double>(std::stod(argv[5]));
         const auto nruns_F = std::stoi(argv[6]);
         const auto nruns_J = std::stoi(argv[7]);
-        const auto time_limit = std::stod(argv[8]);
+        const auto time_limit = duration<double>(std::stod(argv[8]));
 
         // read only 1 point and replicate it?
         const auto replicate_point = (argc > 9 && string(argv[9]) == "-rep");

--- a/test/cpp/modules/manual/CMakeLists.txt
+++ b/test/cpp/modules/manual/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(manualTests GmmTests.cpp BaTests.cpp "${CMAKE_SOURCE_DIR}/src/cpp
 
 add_test("manualtests" manualTests)
 add_dependencies(manualTests Manual)
-target_link_libraries(manualTests PUBLIC GMock::main)
+target_link_libraries(manualTests PUBLIC GTest::main)
 add_custom_command(TARGET manualTests PRE_BUILD 
     COMMAND "${CMAKE_COMMAND}" -E copy 
         "${CMAKE_SOURCE_DIR}/data/gmm/test.txt"

--- a/test/cpp/modules/manual/CMakeLists.txt
+++ b/test/cpp/modules/manual/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(manualTests GmmTests.cpp BaTests.cpp "${CMAKE_SOURCE_DIR}/src/cpp
 
 add_test("manualtests" manualTests)
 add_dependencies(manualTests Manual)
-target_link_libraries(manualTests PUBLIC GTest::main)
+target_link_libraries(manualTests PUBLIC GMock::main)
 add_custom_command(TARGET manualTests PRE_BUILD 
     COMMAND "${CMAKE_COMMAND}" -E copy 
         "${CMAKE_SOURCE_DIR}/data/gmm/test.txt"

--- a/test/cpp/runner/CMakeLists.txt
+++ b/test/cpp/runner/CMakeLists.txt
@@ -1,7 +1,9 @@
 project("CppRunnerTests" CXX)
 
 add_executable(cppRunnerTests CppRunnerTests.cpp "../../../src/cpp/runner/ModuleLoader.cpp")
-add_library("MockGMM" MODULE "MockGMM.cpp")
+target_link_libraries(cppRunnerTests PUBLIC GMock::main) 
+
+add_library(MockGMM MODULE "MockGMM.cpp")
+target_link_libraries(MockGMM PUBLIC GMock::main) 
 
 add_test("cppRunnerTests" cppRunnerTests)
-target_link_libraries(cppRunnerTests PUBLIC GTest::main) 

--- a/test/cpp/runner/CppRunnerTests.cpp
+++ b/test/cpp/runner/CppRunnerTests.cpp
@@ -20,6 +20,22 @@ TEST(CppRunnerTests, LibraryLoadTest) {
     ASSERT_TRUE(module_loader.get_gmm_test() != nullptr);
 }
 
+TEST(CppRunnerTests, TimeLimit) {
+    ModuleLoader module_loader(module_path);
+
+    auto gmm_test = module_loader.get_gmm_test();
+    const auto minimum_measurable_time = 0;
+    const auto run_count = 100; //Run count guarantees total time greater than the time_limit
+    const auto time_limit = 0.1s;
+    const auto execution_time = 0.01s;
+
+    EXPECT_CALL(dynamic_cast<MockGMM&>(*gmm_test.get()), calculateObjective(_))
+        .Times(testing::AtMost(static_cast<int>(time_limit/execution_time))) //Number of runs should be less then run_count variable because total_time will be reached. 
+        .WillRepeatedly(testing::Invoke([execution_time](auto a) { std::this_thread::sleep_for(execution_time); }));
+
+    auto shortest_time = measure_shortest_time(minimum_measurable_time, run_count, time_limit.count(), gmm_test, &ITest<GMMInput, GMMOutput>::calculateObjective);
+}
+
 TEST(CppRunnerTests, TimeMeasurement) {
     ModuleLoader module_loader(module_path);
 

--- a/test/cpp/runner/CppRunnerTests.cpp
+++ b/test/cpp/runner/CppRunnerTests.cpp
@@ -15,14 +15,14 @@ const auto module_path = "MockGMMd.dll";
 const auto module_path = "MockGMM.dll";
 #endif
 
-TEST(CppRunnerTests, LibraryLoadTest) {
-    ModuleLoader module_loader(module_path);
+ModuleLoader module_loader(module_path);
 
+TEST(CppRunnerTests, LibraryLoadTest) {
+   
     ASSERT_TRUE(module_loader.get_gmm_test() != nullptr);
 }
 
 TEST(CppRunnerTests, TimeLimit) {
-    ModuleLoader module_loader(module_path);
 
     auto gmm_test = module_loader.get_gmm_test();
     const auto minimum_measurable_time = 0s;
@@ -38,7 +38,6 @@ TEST(CppRunnerTests, TimeLimit) {
 }
 
 TEST(CppRunnerTests, NumberOfRunsLimit) {
-    ModuleLoader module_loader(module_path);
 
     auto gmm_test = module_loader.get_gmm_test();
     const auto minimum_measurable_time = 0s;
@@ -50,11 +49,10 @@ TEST(CppRunnerTests, NumberOfRunsLimit) {
         .Times(testing::Exactly(run_count)) //Number of runs should be equal to run_count limit.
         .WillRepeatedly(testing::Invoke([execution_time](auto a) { std::this_thread::sleep_for(execution_time); }));
 
-    auto shortest_time = measure_shortest_time(minimum_measurable_time, run_count, time_limit, gmm_test, &ITest<GMMInput, GMMOutput>::calculateObjective);
+    measure_shortest_time(minimum_measurable_time, run_count, time_limit, gmm_test, &ITest<GMMInput, GMMOutput>::calculateObjective);
 }
 
 TEST(CppRunnerTests, TimeMeasurement) {
-    ModuleLoader module_loader(module_path);
 
     auto gmm_test = module_loader.get_gmm_test();
     const auto minimum_measurable_time = 0s;
@@ -72,7 +70,6 @@ TEST(CppRunnerTests, TimeMeasurement) {
 }
 
 TEST(CppRunnerTests, SearchForRepeats) {
-    ModuleLoader module_loader(module_path);
 
     auto gmm_test = module_loader.get_gmm_test();
     const auto assumed_repeats = 16;

--- a/test/cpp/runner/CppRunnerTests.cpp
+++ b/test/cpp/runner/CppRunnerTests.cpp
@@ -30,7 +30,7 @@ TEST(CppRunnerTests, TimeLimit) {
     const auto execution_time = 0.01s;
 
     EXPECT_CALL(dynamic_cast<MockGMM&>(*gmm_test.get()), calculateObjective(_))
-        .Times(testing::AtMost(static_cast<int>(time_limit/execution_time))) //Number of runs should be less then run_count variable because total_time will be reached. 
+        .Times(testing::AtMost(static_cast<int>(time_limit / execution_time))) //Number of runs should be less then run_count variable because total_time will be reached. 
         .WillRepeatedly(testing::Invoke([execution_time](auto a) { std::this_thread::sleep_for(execution_time); }));
 
     auto shortest_time = measure_shortest_time(minimum_measurable_time, run_count, time_limit.count(), gmm_test, &ITest<GMMInput, GMMOutput>::calculateObjective);
@@ -41,7 +41,7 @@ TEST(CppRunnerTests, NumberOfRunsLimit) {
 
     auto gmm_test = module_loader.get_gmm_test();
     const auto minimum_measurable_time = 0;
-    const auto run_count = 10; 
+    const auto run_count = 10;
     const auto time_limit = 10s;
     const auto execution_time = 0.01s;
 
@@ -56,8 +56,8 @@ TEST(CppRunnerTests, TimeMeasurement) {
     ModuleLoader module_loader(module_path);
 
     auto gmm_test = module_loader.get_gmm_test();
-    const auto minimum_measurable_time = 0.0000001;
-    const auto run_count = 100;
+    const auto minimum_measurable_time = 0;
+    const auto run_count = 10;
     const auto time_limit = 100000;
     const auto execution_time = 0.01s;
 
@@ -69,4 +69,21 @@ TEST(CppRunnerTests, TimeMeasurement) {
 
     ASSERT_GE(shortest_time, execution_time.count());
 
+}
+
+TEST(CppRunnerTests, SearchForRepeats) {
+    ModuleLoader module_loader(module_path);
+
+    auto gmm_test = module_loader.get_gmm_test();
+    const auto assumed_repeats = 16;
+    const auto minimum_measurable_time = 0.01;
+    const auto time_limit = 1s;
+    const auto execution_time = 0.001s;
+
+    auto min_sample = std::numeric_limits<double>::max();
+    double total_time = 0;
+    auto repeats = find_repeats_for_minimum_measurable_time(minimum_measurable_time, gmm_test,
+                                                            &ITest<GMMInput, GMMOutput>::calculateObjective, min_sample,
+                                                            total_time);
+    ASSERT_GE(repeats, assumed_repeats);
 }

--- a/test/cpp/runner/CppRunnerTests.cpp
+++ b/test/cpp/runner/CppRunnerTests.cpp
@@ -20,17 +20,21 @@ TEST(CppRunnerTests, LibraryLoadTest) {
     ASSERT_TRUE(module_loader.get_gmm_test() != nullptr);
 }
 
-TEST(CppRunnerTests, Execution) {
+TEST(CppRunnerTests, TimeMeasurement) {
     ModuleLoader module_loader(module_path);
 
     auto gmm_test = module_loader.get_gmm_test();
-    const auto minimum_measurable_time = 0.1;
+    const auto minimum_measurable_time = 0.0000001;
     const auto run_count = 100;
-    const auto time_limit = 100;
+    const auto time_limit = 100000;
+    const auto execution_time = 0.01s;
 
     EXPECT_CALL(dynamic_cast<MockGMM&>(*gmm_test.get()), calculateObjective(_))
-        .Times(testing::Exactly(run_count))
-        .WillRepeatedly(testing::Invoke([](auto a) { std::this_thread::sleep_for(0.01s); }));
+        .Times(testing::Exactly(run_count + 1))
+        .WillRepeatedly(testing::Invoke([execution_time](auto a) { std::this_thread::sleep_for(execution_time); }));
 
-    auto a = measure_shortest_time(minimum_measurable_time, run_count, time_limit, gmm_test, &ITest<GMMInput, GMMOutput>::calculateObjective);
+    auto shortest_time = measure_shortest_time(minimum_measurable_time, run_count, time_limit, gmm_test, &ITest<GMMInput, GMMOutput>::calculateObjective);
+
+    ASSERT_GE(shortest_time, execution_time.count());
+
 }

--- a/test/cpp/runner/CppRunnerTests.cpp
+++ b/test/cpp/runner/CppRunnerTests.cpp
@@ -75,10 +75,7 @@ TEST(CppRunnerTests, SearchForRepeats) {
     const auto assumed_repeats = 16;
     const auto minimum_measurable_time = 0.01s;
     
-    auto min_sample = duration<double>(seconds(std::numeric_limits<seconds::rep>::max()));
-    auto total_time = duration<double>(0s);
-    auto repeats = find_repeats_for_minimum_measurable_time(minimum_measurable_time, gmm_test,
-                                                            &ITest<GMMInput, GMMOutput>::calculateObjective, min_sample,
-                                                            total_time);
-    ASSERT_GE(repeats, assumed_repeats);
+    auto result = find_repeats_for_minimum_measurable_time(minimum_measurable_time, gmm_test,
+                                                            &ITest<GMMInput, GMMOutput>::calculateObjective);
+    ASSERT_GE(result.repeats, assumed_repeats);
 }

--- a/test/cpp/runner/CppRunnerTests.cpp
+++ b/test/cpp/runner/CppRunnerTests.cpp
@@ -5,6 +5,7 @@
 #include "../../../src/cpp/runner/Benchmark.h"
 #include "MockGMM.h"
 #include <thread>
+#include <cmath>
 
 using ::chrono::seconds;
 using ::testing::_;
@@ -31,7 +32,8 @@ TEST(CppRunnerTests, TimeLimit) {
     const auto execution_time = 0.01s;
 
     EXPECT_CALL(dynamic_cast<MockGMM&>(*gmm_test.get()), calculateObjective(_))
-        .Times(testing::AtMost(static_cast<int>(time_limit / execution_time))) //Number of runs should be less then run_count variable because total_time will be reached. 
+        //Number of runs should be less then run_count variable because total_time will be reached. 
+        .Times(testing::AtMost(static_cast<int>(std::ceil(time_limit / execution_time)))) 
         .WillRepeatedly(testing::Invoke([execution_time](auto a) { std::this_thread::sleep_for(execution_time); }));
 
     measure_shortest_time(minimum_measurable_time, run_count, time_limit, gmm_test, &ITest<GMMInput, GMMOutput>::calculateObjective);
@@ -76,6 +78,6 @@ TEST(CppRunnerTests, SearchForRepeats) {
     const auto minimum_measurable_time = 0.01s;
     
     auto result = find_repeats_for_minimum_measurable_time(minimum_measurable_time, gmm_test,
-                                                            &ITest<GMMInput, GMMOutput>::calculateObjective);
+                                                           &ITest<GMMInput, GMMOutput>::calculateObjective);
     ASSERT_GE(result.repeats, assumed_repeats);
 }

--- a/test/cpp/runner/CppRunnerTests.cpp
+++ b/test/cpp/runner/CppRunnerTests.cpp
@@ -26,9 +26,12 @@ TEST(CppRunnerTests, LibraryLoadTest) {
 TEST(CppRunnerTests, TimeLimit) {
 
     auto gmm_test = module_loader.get_gmm_test();
-    const auto minimum_measurable_time = 0s;
-    const auto run_count = 100; //Run count guarantees total time greater than the time_limit
+    //Run_count guarantees total time greater than the time_limit
+    const auto run_count = 100; 
     const auto time_limit = 0.1s;
+    //Execution_time should be more than minimum_measurable_time 
+    //because we can expect find_repeats_for_minimum_measurable_time to call calculateObjective function only once in that case.
+    const auto minimum_measurable_time = 0s;
     const auto execution_time = 0.01s;
 
     EXPECT_CALL(dynamic_cast<MockGMM&>(*gmm_test.get()), calculateObjective(_))

--- a/test/cpp/runner/CppRunnerTests.cpp
+++ b/test/cpp/runner/CppRunnerTests.cpp
@@ -36,6 +36,22 @@ TEST(CppRunnerTests, TimeLimit) {
     auto shortest_time = measure_shortest_time(minimum_measurable_time, run_count, time_limit.count(), gmm_test, &ITest<GMMInput, GMMOutput>::calculateObjective);
 }
 
+TEST(CppRunnerTests, NumberOfRunsLimit) {
+    ModuleLoader module_loader(module_path);
+
+    auto gmm_test = module_loader.get_gmm_test();
+    const auto minimum_measurable_time = 0;
+    const auto run_count = 10; 
+    const auto time_limit = 10s;
+    const auto execution_time = 0.01s;
+
+    EXPECT_CALL(dynamic_cast<MockGMM&>(*gmm_test.get()), calculateObjective(_))
+        .Times(testing::Exactly(run_count)) //Number of runs should be equal to run_count limit.
+        .WillRepeatedly(testing::Invoke([execution_time](auto a) { std::this_thread::sleep_for(execution_time); }));
+
+    auto shortest_time = measure_shortest_time(minimum_measurable_time, run_count, time_limit.count(), gmm_test, &ITest<GMMInput, GMMOutput>::calculateObjective);
+}
+
 TEST(CppRunnerTests, TimeMeasurement) {
     ModuleLoader module_loader(module_path);
 

--- a/test/cpp/runner/CppRunnerTests.cpp
+++ b/test/cpp/runner/CppRunnerTests.cpp
@@ -1,12 +1,36 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
 #include "../../../src/cpp/runner/ModuleLoader.h"
+#include "../../../src/cpp/runner/Benchmark.h"
+#include "MockGMM.h"
+#include <thread>
+
+using ::testing::_;
+
+#ifdef _DEBUG
+const auto module_path = "MockGMMd.dll";
+#else
+const auto module_path = "MockGMM.dll";
+#endif
 
 TEST(CppRunnerTests, LibraryLoadTest) {
-#ifdef _DEBUG
-    ModuleLoader moduleLoader("MockGMMd.dll");
-#else
-    ModuleLoader moduleLoader("MockGMM.dll");
-#endif
-	auto test = moduleLoader.get_gmm_test();
-    ASSERT_TRUE(test != NULL);
+    ModuleLoader module_loader(module_path);
+
+    ASSERT_TRUE(module_loader.get_gmm_test() != nullptr);
+}
+
+TEST(CppRunnerTests, Execution) {
+    ModuleLoader module_loader(module_path);
+
+    auto gmm_test = module_loader.get_gmm_test();
+    const auto minimum_measurable_time = 0.1;
+    const auto run_count = 100;
+    const auto time_limit = 100;
+
+    EXPECT_CALL(dynamic_cast<MockGMM&>(*gmm_test.get()), calculateObjective(_))
+        .Times(testing::Exactly(run_count))
+        .WillRepeatedly(testing::Invoke([](auto a) { std::this_thread::sleep_for(0.01s); }));
+
+    auto a = measure_shortest_time(minimum_measurable_time, run_count, time_limit, gmm_test, &ITest<GMMInput, GMMOutput>::calculateObjective);
 }

--- a/test/cpp/runner/MockGMM.cpp
+++ b/test/cpp/runner/MockGMM.cpp
@@ -19,10 +19,6 @@ GMMOutput MockGMM::output()
     return GMMOutput();
 }
 
-void MockGMM::calculateObjective(int times)
-{
-}
-
 void MockGMM::calculateJacobian(int times)
 {
 }

--- a/test/cpp/runner/MockGMM.h
+++ b/test/cpp/runner/MockGMM.h
@@ -1,19 +1,22 @@
 #pragma once
 
+#include <gmock/gmock.h>
+
 #include "../../../src/cpp/shared/ITest.h"
 #include "../../../src/cpp/shared/GMMData.h"
 
 class MockGMM : public ITest<GMMInput, GMMOutput> {
-    // This function must be called before any other function.
-    virtual void prepare(GMMInput&& input) override;
+public:
+    //This function must be called before any other function.
+    void prepare(GMMInput&& input) override;
 
-    virtual void calculateObjective(int times) override;
-    virtual void calculateJacobian(int times) override;
+    MOCK_METHOD1(calculateObjective, void(int times));
+    void calculateJacobian(int times) override;
 
-    // 
-    virtual GMMOutput output() override; //TODO: should be not void
+    //Returns results of calculation
+    GMMOutput output() override; 
 
-    ~MockGMM() {}
+    ~MockGMM() = default;
 
     // Inherited via ITest
 


### PR DESCRIPTION
-Time always passes as duration<double> instead double. It helps to understand that time measures in seconds.
-Implemented a test which checks benchmark interrupt after exceeding the timelimit.
-Implemented a test which checks benchmark interrupt after exceeding the run limit. Moreover it checks that benchmarking loop is not optimized.
-Implemented a test which checks the function calculating repeats necessary for minimum measurement time archivement.
-Implemented a test which checks that time measured correctly.
