### PR TITLE
Modules API Pascal and camel to snake case + Linux build fix

### DIFF
--- a/src/cpp/modules/finite/FiniteBA.cpp
+++ b/src/cpp/modules/finite/FiniteBA.cpp
@@ -18,7 +18,7 @@ BAOutput FiniteBA::output()
     return result;
 }
 
-void FiniteBA::calculateObjective(int times)
+void FiniteBA::calculate_objective(int times)
 {
     for (int i = 0; i < times; ++i) {
         ba_objective(input.n, input.m, input.p, input.cams.data(), input.X.data(), input.w.data(),
@@ -26,7 +26,7 @@ void FiniteBA::calculateObjective(int times)
     }
 }
 
-void FiniteBA::calculateJacobian(int times)
+void FiniteBA::calculate_jacobian(int times)
 {
     for (int i = 0; i < times; ++i) {
         result.J.clear();

--- a/src/cpp/modules/finite/FiniteBA.cpp
+++ b/src/cpp/modules/finite/FiniteBA.cpp
@@ -65,7 +65,7 @@ void FiniteBA::calculateJacobian(int times)
     }
 }
 
-extern "C" DLL_PUBLIC ITest<BAInput, BAOutput>* GetBATest()
+extern "C" DLL_PUBLIC ITest<BAInput, BAOutput>* get_ba_test()
 {
     return new FiniteBA();
 }

--- a/src/cpp/modules/finite/FiniteBA.h
+++ b/src/cpp/modules/finite/FiniteBA.h
@@ -18,8 +18,8 @@ public:
     // This function must be called before any other function.
     virtual void prepare(BAInput&& input) override;
 
-    virtual void calculateObjective(int times) override;
-    virtual void calculateJacobian(int times) override;
+    virtual void calculate_objective(int times) override;
+    virtual void calculate_jacobian(int times) override;
     virtual BAOutput output() override;
 
     ~FiniteBA() = default;

--- a/src/cpp/modules/finite/FiniteGMM.cpp
+++ b/src/cpp/modules/finite/FiniteGMM.cpp
@@ -42,7 +42,7 @@ void FiniteGMM::calculateJacobian(int times)
     }
 }
 
-extern "C" DLL_PUBLIC ITest<GMMInput, GMMOutput>* GetGMMTest()
+extern "C" DLL_PUBLIC ITest<GMMInput, GMMOutput>* get_gmm_test()
 {
     return new FiniteGMM();
 }

--- a/src/cpp/modules/finite/FiniteGMM.cpp
+++ b/src/cpp/modules/finite/FiniteGMM.cpp
@@ -17,7 +17,7 @@ GMMOutput FiniteGMM::output()
     return result;
 }
 
-void FiniteGMM::calculateObjective(int times)
+void FiniteGMM::calculate_objective(int times)
 {
     for (int i = 0; i < times; ++i) {
         gmm_objective(input.d, input.k, input.n, input.alphas.data(), input.means.data(),
@@ -25,7 +25,7 @@ void FiniteGMM::calculateObjective(int times)
     }
 }
 
-void FiniteGMM::calculateJacobian(int times)
+void FiniteGMM::calculate_jacobian(int times)
 {
     for (int i = 0; i < times; ++i) {
         engine.finite_differences([&](double* alphas_in, double* err) {

--- a/src/cpp/modules/finite/FiniteGMM.h
+++ b/src/cpp/modules/finite/FiniteGMM.h
@@ -13,8 +13,8 @@ public:
     // This function must be called before any other function.
     void prepare(GMMInput&& input) override;
 
-    void calculateObjective(int times) override;
-    void calculateJacobian(int times) override;
+    void calculate_objective(int times) override;
+    void calculate_jacobian(int times) override;
     GMMOutput output() override;
 
     ~FiniteGMM() = default;

--- a/src/cpp/modules/finite/FiniteHand.cpp
+++ b/src/cpp/modules/finite/FiniteHand.cpp
@@ -22,7 +22,7 @@ HandOutput FiniteHand::output()
     return result;
 }
 
-void FiniteHand::calculateObjective(int times)
+void FiniteHand::calculate_objective(int times)
 {
     if (complicated)
     {
@@ -38,7 +38,7 @@ void FiniteHand::calculateObjective(int times)
     }
 }
 
-void FiniteHand::calculateJacobian(int times)
+void FiniteHand::calculate_jacobian(int times)
 {
     if (complicated)
     {

--- a/src/cpp/modules/finite/FiniteHand.cpp
+++ b/src/cpp/modules/finite/FiniteHand.cpp
@@ -70,7 +70,7 @@ void FiniteHand::calculateJacobian(int times)
     }
 }
 
-extern "C" DLL_PUBLIC ITest<HandInput, HandOutput>* GetHandTest()
+extern "C" DLL_PUBLIC ITest<HandInput, HandOutput>* get_hand_test()
 {
     return new FiniteHand();
 }

--- a/src/cpp/modules/finite/FiniteHand.h
+++ b/src/cpp/modules/finite/FiniteHand.h
@@ -16,8 +16,8 @@ public:
     // This function must be called before any other function.
     void prepare(HandInput&& input) override;
 
-    void calculateObjective(int times) override;
-    void calculateJacobian(int times) override;
+    void calculate_objective(int times) override;
+    void calculate_jacobian(int times) override;
     HandOutput output() override;
 
     ~FiniteHand() = default;

--- a/src/cpp/modules/finite/FiniteLSTM.cpp
+++ b/src/cpp/modules/finite/FiniteLSTM.cpp
@@ -42,7 +42,7 @@ void FiniteLSTM::calculateJacobian(int times)
     }
 }
 
-extern "C" DLL_PUBLIC ITest<LSTMInput, LSTMOutput>*  GetLSTMTest()
+extern "C" DLL_PUBLIC ITest<LSTMInput, LSTMOutput>*  get_lstm_test()
 {
     return new FiniteLSTM();
 }

--- a/src/cpp/modules/finite/FiniteLSTM.cpp
+++ b/src/cpp/modules/finite/FiniteLSTM.cpp
@@ -18,7 +18,7 @@ LSTMOutput FiniteLSTM::output()
     return result;
 }
 
-void FiniteLSTM::calculateObjective(int times)
+void FiniteLSTM::calculate_objective(int times)
 {
     for (int i = 0; i < times; ++i) {
         state = input.state;
@@ -26,7 +26,7 @@ void FiniteLSTM::calculateObjective(int times)
     }
 }
 
-void FiniteLSTM::calculateJacobian(int times)
+void FiniteLSTM::calculate_jacobian(int times)
 {
     for (int i = 0; i < times; ++i) {
         state = input.state;

--- a/src/cpp/modules/finite/FiniteLSTM.h
+++ b/src/cpp/modules/finite/FiniteLSTM.h
@@ -18,8 +18,8 @@ public:
     // This function must be called before any other function.
     virtual void prepare(LSTMInput&& input) override;
 
-    virtual void calculateObjective(int times) override;
-    virtual void calculateJacobian(int times) override;
+    virtual void calculate_objective(int times) override;
+    virtual void calculate_jacobian(int times) override;
     virtual LSTMOutput output() override;
 
     ~FiniteLSTM() {}

--- a/src/cpp/modules/finiteEigen/FiniteEigenHand.cpp
+++ b/src/cpp/modules/finiteEigen/FiniteEigenHand.cpp
@@ -71,7 +71,7 @@ void FiniteEigenHand::calculateJacobian(int times)
     }
 }
 
-extern "C" DLL_PUBLIC ITest<HandInput, HandOutput>* GetHandTest()
+extern "C" DLL_PUBLIC ITest<HandInput, HandOutput>* get_hand_test()
 {
     return new FiniteEigenHand();
 }

--- a/src/cpp/modules/finiteEigen/FiniteEigenHand.cpp
+++ b/src/cpp/modules/finiteEigen/FiniteEigenHand.cpp
@@ -23,7 +23,7 @@ HandOutput FiniteEigenHand::output()
     return result;
 }
 
-void FiniteEigenHand::calculateObjective(int times)
+void FiniteEigenHand::calculate_objective(int times)
 {
     if (complicated)
     {
@@ -39,7 +39,7 @@ void FiniteEigenHand::calculateObjective(int times)
     }
 }
 
-void FiniteEigenHand::calculateJacobian(int times)
+void FiniteEigenHand::calculate_jacobian(int times)
 {
     if (complicated)
     {

--- a/src/cpp/modules/finiteEigen/FiniteEigenHand.h
+++ b/src/cpp/modules/finiteEigen/FiniteEigenHand.h
@@ -17,8 +17,8 @@ public:
     // This function must be called before any other function.
     void prepare(HandInput&& input) override;
 
-    void calculateObjective(int times) override;
-    void calculateJacobian(int times) override;
+    void calculate_objective(int times) override;
+    void calculate_jacobian(int times) override;
     HandOutput output() override;
 
     ~FiniteEigenHand() = default;

--- a/src/cpp/modules/manual/ManualBA.cpp
+++ b/src/cpp/modules/manual/ManualBA.cpp
@@ -56,7 +56,7 @@ void ManualBA::calculateJacobian(int times)
     }
 }
 
-extern "C" DLL_PUBLIC ITest<BAInput, BAOutput>* GetBATest()
+extern "C" DLL_PUBLIC ITest<BAInput, BAOutput>* get_ba_test()
 {
     return new ManualBA();
 }

--- a/src/cpp/modules/manual/ManualBA.cpp
+++ b/src/cpp/modules/manual/ManualBA.cpp
@@ -17,7 +17,7 @@ BAOutput ManualBA::output()
     return _output;
 }
 
-void ManualBA::calculateObjective(int times)
+void ManualBA::calculate_objective(int times)
 {
     for (int i = 0; i < times; ++i) {
         ba_objective(_input.n, _input.m, _input.p, _input.cams.data(), _input.X.data(), _input.w.data(),
@@ -25,7 +25,7 @@ void ManualBA::calculateObjective(int times)
     }
 }
 
-void ManualBA::calculateJacobian(int times)
+void ManualBA::calculate_jacobian(int times)
 {
     for (int i = 0; i < times; ++i) {
         _output.J.clear();

--- a/src/cpp/modules/manual/ManualBA.h
+++ b/src/cpp/modules/manual/ManualBA.h
@@ -16,8 +16,8 @@ public:
     // This function must be called before any other function.
     virtual void prepare(BAInput&& input) override;
 
-    virtual void calculateObjective(int times) override;
-    virtual void calculateJacobian(int times) override;
+    virtual void calculate_objective(int times) override;
+    virtual void calculate_jacobian(int times) override;
     virtual BAOutput output() override;
 
     ~ManualBA() {}

--- a/src/cpp/modules/manual/ManualGMM.cpp
+++ b/src/cpp/modules/manual/ManualGMM.cpp
@@ -34,7 +34,7 @@ void ManualGMM::calculateJacobian(int times)
     }
 }
 
-extern "C" DLL_PUBLIC ITest<GMMInput, GMMOutput>* GetGMMTest()
+extern "C" DLL_PUBLIC ITest<GMMInput, GMMOutput>* get_gmm_test()
 {
     return new ManualGMM();
 }

--- a/src/cpp/modules/manual/ManualGMM.cpp
+++ b/src/cpp/modules/manual/ManualGMM.cpp
@@ -18,7 +18,7 @@ GMMOutput ManualGMM::output()
     return _output;
 }
 
-void ManualGMM::calculateObjective(int times)
+void ManualGMM::calculate_objective(int times)
 {
     for (int i = 0; i < times; ++i) {
         gmm_objective(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(),
@@ -26,7 +26,7 @@ void ManualGMM::calculateObjective(int times)
     }
 }
 
-void ManualGMM::calculateJacobian(int times)
+void ManualGMM::calculate_jacobian(int times)
 {
     for (int i = 0; i < times; ++i) {
         gmm_objective_d(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(),

--- a/src/cpp/modules/manual/ManualGMM.h
+++ b/src/cpp/modules/manual/ManualGMM.h
@@ -14,8 +14,8 @@ public:
     // This function must be called before any other function.
     void prepare(GMMInput&& input) override;
 
-    void calculateObjective(int times) override;
-    void calculateJacobian(int times) override;
+    void calculate_objective(int times) override;
+    void calculate_jacobian(int times) override;
     GMMOutput output() override; 
 
     ~ManualGMM() = default;

--- a/src/cpp/modules/manual/ManualHand.cpp
+++ b/src/cpp/modules/manual/ManualHand.cpp
@@ -19,7 +19,7 @@ HandOutput ManualHand::output()
     return _output;
 }
 
-void ManualHand::calculateObjective(int times)
+void ManualHand::calculate_objective(int times)
 {
     if (_complicated)
     {
@@ -35,7 +35,7 @@ void ManualHand::calculateObjective(int times)
     }
 }
 
-void ManualHand::calculateJacobian(int times)
+void ManualHand::calculate_jacobian(int times)
 {
     if (_complicated)
     {

--- a/src/cpp/modules/manual/ManualHand.cpp
+++ b/src/cpp/modules/manual/ManualHand.cpp
@@ -51,7 +51,7 @@ void ManualHand::calculateJacobian(int times)
     }
 }
 
-extern "C" DLL_PUBLIC ITest<HandInput, HandOutput>* GetHandTest()
+extern "C" DLL_PUBLIC ITest<HandInput, HandOutput>* get_hand_test()
 {
     return new ManualHand();
 }

--- a/src/cpp/modules/manual/ManualHand.h
+++ b/src/cpp/modules/manual/ManualHand.h
@@ -13,8 +13,8 @@ public:
     // This function must be called before any other function.
     void prepare(HandInput&& input) override;
 
-    void calculateObjective(int times) override;
-    void calculateJacobian(int times) override;
+    void calculate_objective(int times) override;
+    void calculate_jacobian(int times) override;
     HandOutput output() override;
 
     ~ManualHand() = default;

--- a/src/cpp/modules/manual/ManualLSTM.cpp
+++ b/src/cpp/modules/manual/ManualLSTM.cpp
@@ -33,7 +33,7 @@ void ManualLSTM::calculateJacobian(int times)
     }
 }
 
-extern "C" DLL_PUBLIC ITest<LSTMInput, LSTMOutput>*  GetLSTMTest()
+extern "C" DLL_PUBLIC ITest<LSTMInput, LSTMOutput>*  get_lstm_test()
 {
     return new ManualLSTM();
 }

--- a/src/cpp/modules/manual/ManualLSTM.cpp
+++ b/src/cpp/modules/manual/ManualLSTM.cpp
@@ -17,7 +17,7 @@ LSTMOutput ManualLSTM::output()
     return result;
 }
 
-void ManualLSTM::calculateObjective(int times)
+void ManualLSTM::calculate_objective(int times)
 {
     for (int i = 0; i < times; ++i) {
         state = input.state;
@@ -25,7 +25,7 @@ void ManualLSTM::calculateObjective(int times)
     }
 }
 
-void ManualLSTM::calculateJacobian(int times)
+void ManualLSTM::calculate_jacobian(int times)
 {
     for (int i = 0; i < times; ++i) {
         state = input.state;

--- a/src/cpp/modules/manual/ManualLSTM.h
+++ b/src/cpp/modules/manual/ManualLSTM.h
@@ -16,8 +16,8 @@ public:
     // This function must be called before any other function.
     virtual void prepare(LSTMInput&& input) override;
 
-    virtual void calculateObjective(int times) override;
-    virtual void calculateJacobian(int times) override;
+    virtual void calculate_objective(int times) override;
+    virtual void calculate_jacobian(int times) override;
     virtual LSTMOutput output() override;
 
     ~ManualLSTM() {}

--- a/src/cpp/modules/manualEigen/ManualEigenBA.cpp
+++ b/src/cpp/modules/manualEigen/ManualEigenBA.cpp
@@ -17,7 +17,7 @@ BAOutput ManualEigenBA::output()
     return _output;
 }
 
-void ManualEigenBA::calculateObjective(int times)
+void ManualEigenBA::calculate_objective(int times)
 {
     for (int i = 0; i < times; ++i) {
         ba_objective(_input.n, _input.m, _input.p, _input.cams.data(), _input.X.data(), _input.w.data(),
@@ -25,7 +25,7 @@ void ManualEigenBA::calculateObjective(int times)
     }
 }
 
-void ManualEigenBA::calculateJacobian(int times)
+void ManualEigenBA::calculate_jacobian(int times)
 {
     for (int t = 0; t < times; ++t) {
         _output.J.clear();

--- a/src/cpp/modules/manualEigen/ManualEigenBA.cpp
+++ b/src/cpp/modules/manualEigen/ManualEigenBA.cpp
@@ -56,7 +56,7 @@ void ManualEigenBA::calculateJacobian(int times)
     }
 }
 
-extern "C" DLL_PUBLIC ITest<BAInput, BAOutput>* GetBATest()
+extern "C" DLL_PUBLIC ITest<BAInput, BAOutput>* get_ba_test()
 {
     return new ManualEigenBA();
 }

--- a/src/cpp/modules/manualEigen/ManualEigenBA.h
+++ b/src/cpp/modules/manualEigen/ManualEigenBA.h
@@ -16,8 +16,8 @@ public:
     // This function must be called before any other function.
     virtual void prepare(BAInput&& input) override;
 
-    virtual void calculateObjective(int times) override;
-    virtual void calculateJacobian(int times) override;
+    virtual void calculate_objective(int times) override;
+    virtual void calculate_jacobian(int times) override;
     virtual BAOutput output() override;
 
     ~ManualEigenBA() {}

--- a/src/cpp/modules/manualEigen/ManualEigenGMM.cpp
+++ b/src/cpp/modules/manualEigen/ManualEigenGMM.cpp
@@ -19,7 +19,7 @@ GMMOutput ManualEigenGMM::output()
     return _output;
 }
 
-void ManualEigenGMM::calculateObjective(int times)
+void ManualEigenGMM::calculate_objective(int times)
 {
     for (int i = 0; i < times; ++i) {
         gmm_objective(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(),
@@ -27,7 +27,7 @@ void ManualEigenGMM::calculateObjective(int times)
     }
 }
 
-void ManualEigenGMM::calculateJacobian(int times)
+void ManualEigenGMM::calculate_jacobian(int times)
 {
     for (int i = 0; i < times; ++i) {
         gmm_objective_d(_input.d, _input.k, _input.n, _input.alphas.data(), _input.means.data(),

--- a/src/cpp/modules/manualEigen/ManualEigenGMM.cpp
+++ b/src/cpp/modules/manualEigen/ManualEigenGMM.cpp
@@ -35,7 +35,7 @@ void ManualEigenGMM::calculateJacobian(int times)
     }
 }
 
-extern "C" DLL_PUBLIC ITest<GMMInput, GMMOutput>* GetGMMTest()
+extern "C" DLL_PUBLIC ITest<GMMInput, GMMOutput>* get_gmm_test()
 {
     return new ManualEigenGMM();
 }

--- a/src/cpp/modules/manualEigen/ManualEigenGMM.h
+++ b/src/cpp/modules/manualEigen/ManualEigenGMM.h
@@ -14,8 +14,8 @@ public:
     // This function must be called before any other function.
     void prepare(GMMInput&& input) override;
 
-    void calculateObjective(int times) override;
-    void calculateJacobian(int times) override;
+    void calculate_objective(int times) override;
+    void calculate_jacobian(int times) override;
     GMMOutput output() override; 
 
     ~ManualEigenGMM() = default;

--- a/src/cpp/modules/manualEigen/ManualEigenHand.cpp
+++ b/src/cpp/modules/manualEigen/ManualEigenHand.cpp
@@ -22,7 +22,7 @@ HandOutput ManualEigenHand::output()
     return _output;
 }
 
-void ManualEigenHand::calculateObjective(int times)
+void ManualEigenHand::calculate_objective(int times)
 {
     if (_complicated)
     {
@@ -38,7 +38,7 @@ void ManualEigenHand::calculateObjective(int times)
     }
 }
 
-void ManualEigenHand::calculateJacobian(int times)
+void ManualEigenHand::calculate_jacobian(int times)
 {
     if (_complicated)
     {

--- a/src/cpp/modules/manualEigen/ManualEigenHand.cpp
+++ b/src/cpp/modules/manualEigen/ManualEigenHand.cpp
@@ -54,7 +54,7 @@ void ManualEigenHand::calculateJacobian(int times)
     }
 }
 
-extern "C" DLL_PUBLIC ITest<HandInput, HandOutput>* GetHandTest()
+extern "C" DLL_PUBLIC ITest<HandInput, HandOutput>* get_hand_test()
 {
     return new ManualEigenHand();
 }

--- a/src/cpp/modules/manualEigen/ManualEigenHand.h
+++ b/src/cpp/modules/manualEigen/ManualEigenHand.h
@@ -16,8 +16,8 @@ public:
     // This function must be called before any other function.
     void prepare(HandInput&& input) override;
 
-    void calculateObjective(int times) override;
-    void calculateJacobian(int times) override;
+    void calculate_objective(int times) override;
+    void calculate_jacobian(int times) override;
     HandOutput output() override;
 
     ~ManualEigenHand() = default;

--- a/src/cpp/runner/Benchmark.h
+++ b/src/cpp/runner/Benchmark.h
@@ -127,10 +127,10 @@ void run_benchmark(const char* const module_path, const std::string& input_filep
     test->prepare(std::move(inputs));
 
     const auto objective_time =
-        measure_shortest_time(minimum_measurable_time, nruns_F, time_limit, *test, &ITest<Input, Output>::calculateObjective);
+        measure_shortest_time(minimum_measurable_time, nruns_F, time_limit, *test, &ITest<Input, Output>::calculate_objective);
 
     const auto derivative_time =
-        measure_shortest_time(minimum_measurable_time, nruns_J, time_limit, *test, &ITest<Input, Output>::calculateJacobian);
+        measure_shortest_time(minimum_measurable_time, nruns_J, time_limit, *test, &ITest<Input, Output>::calculate_jacobian);
 
     const auto output = test->output();
 

--- a/src/cpp/runner/ModuleLoader.cpp
+++ b/src/cpp/runner/ModuleLoader.cpp
@@ -26,14 +26,14 @@ typedef ITest<GMMInput, GMMOutput>* (*GmmTestFuncPtr)();
 
 std::unique_ptr<ITest<GMMInput, GMMOutput>> ModuleLoader::get_gmm_test() const
 {
-    auto GetGMMTest = (GmmTestFuncPtr)load_function("GetGMMTest");
-    if (GetGMMTest != nullptr)
+    auto get_gmm_test = (GmmTestFuncPtr)load_function("get_gmm_test");
+    if (get_gmm_test != nullptr)
     {
-        return std::unique_ptr<ITest<GMMInput, GMMOutput>>(GetGMMTest());
+        return std::unique_ptr<ITest<GMMInput, GMMOutput>>(get_gmm_test());
     }
     else
     {
-        throw runtime_error("Can't load GetGMMTest function");
+        throw runtime_error("Can't load get_gmm_test function");
     }
 }
 
@@ -41,14 +41,14 @@ typedef ITest<BAInput, BAOutput>* (*BaTestFuncPtr)();
 
 std::unique_ptr<ITest<BAInput, BAOutput>> ModuleLoader::get_ba_test() const
 {
-    auto GetBATest = (BaTestFuncPtr)load_function("GetBATest");
-    if (GetBATest != nullptr)
+    auto get_ba_test = (BaTestFuncPtr)load_function("get_ba_test");
+    if (get_ba_test != nullptr)
     {
-        return std::unique_ptr<ITest<BAInput, BAOutput>>(GetBATest());
+        return std::unique_ptr<ITest<BAInput, BAOutput>>(get_ba_test());
     }
     else
     {
-        throw runtime_error("Can't load GetGMMTest function");
+        throw runtime_error("Can't load get_ba_test function");
     }
 }
 
@@ -56,14 +56,14 @@ typedef ITest<HandInput, HandOutput>* (*HandTestFuncPtr)();
 
 std::unique_ptr<ITest<HandInput, HandOutput>> ModuleLoader::get_hand_test() const
 {
-    auto GetHandTest = (HandTestFuncPtr)load_function("GetHandTest");
-    if (GetHandTest != nullptr)
+    auto get_hand_test = (HandTestFuncPtr)load_function("get_hand_test");
+    if (get_hand_test != nullptr)
     {
-        return std::unique_ptr<ITest<HandInput, HandOutput>>(GetHandTest());
+        return std::unique_ptr<ITest<HandInput, HandOutput>>(get_hand_test());
     }
     else
     {
-        throw runtime_error("Can't load GetHandTest function");
+        throw runtime_error("Can't load get_hand_test function");
     }
 }
 
@@ -71,14 +71,14 @@ typedef ITest<LSTMInput, LSTMOutput>* (*LSTMTestFuncPtr)();
 
 std::unique_ptr<ITest<LSTMInput, LSTMOutput>> ModuleLoader::get_lstm_test() const
 {
-    auto GetLSTMTest = (LSTMTestFuncPtr)load_function("GetLSTMTest");
-    if (GetLSTMTest != nullptr)
+    auto get_lstm_test = (LSTMTestFuncPtr)load_function("get_lstm_test");
+    if (get_lstm_test != nullptr)
     {
-        return std::unique_ptr<ITest<LSTMInput, LSTMOutput>>(GetLSTMTest());
+        return std::unique_ptr<ITest<LSTMInput, LSTMOutput>>(get_lstm_test());
     }
     else
     {
-        throw runtime_error("Can't load GetLSTMTest function");
+        throw runtime_error("Can't load get_lstm_test function");
     }
 }
 

--- a/src/cpp/shared/HandEigenData.h
+++ b/src/cpp/shared/HandEigenData.h
@@ -1,6 +1,6 @@
 #pragma once 
 
-#include "../../shared/hand_eigen_model.h"
+#include "./hand_eigen_model.h"
 
 #include <Eigen/Dense>
 #include <Eigen/StdVector>

--- a/src/cpp/shared/ITest.h
+++ b/src/cpp/shared/ITest.h
@@ -22,8 +22,8 @@ public:
     // This function must be called before any other function.
     virtual void prepare(Input&& input) = 0;
     // calculate function
-    virtual void calculateObjective(int times) = 0;
-    virtual void calculateJacobian(int times) = 0;
+    virtual void calculate_objective(int times) = 0;
+    virtual void calculate_jacobian(int times) = 0;
     virtual Output output() = 0;
     virtual ~ITest() = 0;
 };

--- a/test/cpp/modules/manual/BaTests.cpp
+++ b/test/cpp/modules/manual/BaTests.cpp
@@ -30,7 +30,7 @@ TEST_P(BaModuleTest, ObjectiveCalculationCorrectness)
     read_ba_instance("batest.txt", input.n, input.m, input.p,
         input.cams, input.X, input.w, input.obs, input.feats);
     module->prepare(std::move(input));
-    module->calculateObjective(1);
+    module->calculate_objective(1);
 
     auto output = module->output();
     for (int i = 0; i < 20; i += 2)
@@ -54,7 +54,7 @@ TEST_P(BaModuleTest, JacobianCalculationCorrectness)
     read_ba_instance("batest.txt", input.n, input.m, input.p,
         input.cams, input.X, input.w, input.obs, input.feats);
     module->prepare(std::move(input));
-    module->calculateJacobian(1);
+    module->calculate_jacobian(1);
 
     auto output = module->output();
     EXPECT_EQ(30, output.J.nrows);
@@ -91,7 +91,7 @@ TEST_P(BaModuleTest, ObjectiveRunsMultipleTimes)
         input.cams, input.X, input.w, input.obs, input.feats);
     module->prepare(std::move(input));
 
-    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<BAInput, BAOutput>::calculateObjective));
+    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<BAInput, BAOutput>::calculate_objective));
 }
 
 TEST_P(BaModuleTest, JacobianRunsMultipleTimes)
@@ -105,5 +105,5 @@ TEST_P(BaModuleTest, JacobianRunsMultipleTimes)
         input.cams, input.X, input.w, input.obs, input.feats);
     module->prepare(std::move(input));
 
-    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<BAInput, BAOutput>::calculateJacobian));
+    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<BAInput, BAOutput>::calculate_jacobian));
 }

--- a/test/cpp/modules/manual/GmmTests.cpp
+++ b/test/cpp/modules/manual/GmmTests.cpp
@@ -31,7 +31,7 @@ TEST_P(GmmModuleTest, ObjectiveCalculationCorrectness)
     read_gmm_instance("gmmtest.txt", &input.d, &input.k, &input.n,
         input.alphas, input.means, input.icf, input.x, input.wishart, false);
     module->prepare(std::move(input));
-    module->calculateObjective(1);
+    module->calculate_objective(1);
 
     auto output = module->output();
     EXPECT_NEAR(8.0738, output.objective, 0.00001);
@@ -47,7 +47,7 @@ TEST_P(GmmModuleTest, JacobianCalculationCorrectness)
     read_gmm_instance("gmmtest.txt", &input.d, &input.k, &input.n,
         input.alphas, input.means, input.icf, input.x, input.wishart, false);
     module->prepare(std::move(input));
-    module->calculateJacobian(1);
+    module->calculate_jacobian(1);
 
     auto output = module->output();
     EXPECT_EQ(18, output.gradient.size());
@@ -82,7 +82,7 @@ TEST_P(GmmModuleTest, ObjectiveRunsMultipleTimes)
         input.alphas, input.means, input.icf, input.x, input.wishart, false);
     module->prepare(std::move(input));
 
-    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<GMMInput, GMMOutput>::calculateObjective));
+    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<GMMInput, GMMOutput>::calculate_objective));
 }
 
 TEST_P(GmmModuleTest, JacobianRunsMultipleTimes)
@@ -96,5 +96,5 @@ TEST_P(GmmModuleTest, JacobianRunsMultipleTimes)
         input.alphas, input.means, input.icf, input.x, input.wishart, false);
     module->prepare(std::move(input));
 
-    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<GMMInput, GMMOutput>::calculateJacobian));
+    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<GMMInput, GMMOutput>::calculate_jacobian));
 }

--- a/test/cpp/modules/manual/HandTests.cpp
+++ b/test/cpp/modules/manual/HandTests.cpp
@@ -30,7 +30,7 @@ TEST_P(HandModuleTest, SimpleObjectiveCalculationCorrectness)
     // Read instance
     read_hand_instance("model/", "handtestsmall.txt", &input.theta, &input.data);
     module->prepare(std::move(input));
-    module->calculateObjective(1);
+    module->calculate_objective(1);
 
     auto output = module->output();
 
@@ -52,7 +52,7 @@ TEST_P(HandModuleTest, SimpleJacobianCalculationCorrectness)
     // Read instance
     read_hand_instance("model/", "handtestsmall.txt", &input.theta, &input.data);
     module->prepare(std::move(input));
-    module->calculateJacobian(1);
+    module->calculate_jacobian(1);
 
     auto output = module->output();
 
@@ -103,7 +103,7 @@ TEST_P(HandModuleTest, ComplicatedObjectiveCalculationCorrectness)
     // Read instance
     read_hand_instance("model/", "handtestcomplicated.txt", &input.theta, &input.data, &input.us);
     module->prepare(std::move(input));
-    module->calculateObjective(1);
+    module->calculate_objective(1);
 
     auto output = module->output();
 
@@ -124,7 +124,7 @@ TEST_P(HandModuleTest, ComplicatedJacobianCalculationCorrectness)
     // Read instance
     read_hand_instance("model/", "handtestcomplicated.txt", &input.theta, &input.data, &input.us);
     module->prepare(std::move(input));
-    module->calculateJacobian(1);
+    module->calculate_jacobian(1);
 
     auto output = module->output();
 
@@ -178,7 +178,7 @@ TEST_P(HandModuleTest, SimpleObjectiveRunsMultipleTimes)
     read_hand_instance("model/", "handtestsmall.txt", &input.theta, &input.data);
     module->prepare(std::move(input));
 
-    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<HandInput, HandOutput>::calculateObjective));
+    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<HandInput, HandOutput>::calculate_objective));
 }
 
 TEST_P(HandModuleTest, SimpleJacobianRunsMultipleTimes)
@@ -191,7 +191,7 @@ TEST_P(HandModuleTest, SimpleJacobianRunsMultipleTimes)
     read_hand_instance("model/", "handtestsmall.txt", &input.theta, &input.data);
     module->prepare(std::move(input));
 
-    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<HandInput, HandOutput>::calculateJacobian));
+    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<HandInput, HandOutput>::calculate_jacobian));
 }
 
 TEST_P(HandModuleTest, ComplicatedObjectiveRunsMultipleTimes)
@@ -204,7 +204,7 @@ TEST_P(HandModuleTest, ComplicatedObjectiveRunsMultipleTimes)
     read_hand_instance("model/", "handtestcomplicated.txt", &input.theta, &input.data, &input.us);
     module->prepare(std::move(input));
 
-    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<HandInput, HandOutput>::calculateObjective));
+    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<HandInput, HandOutput>::calculate_objective));
 }
 
 TEST_P(HandModuleTest, ComplicatedJacobianRunsMultipleTimes)
@@ -217,5 +217,5 @@ TEST_P(HandModuleTest, ComplicatedJacobianRunsMultipleTimes)
     read_hand_instance("model/", "handtestcomplicated.txt", &input.theta, &input.data, &input.us);
     module->prepare(std::move(input));
 
-    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<HandInput, HandOutput>::calculateJacobian));
+    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<HandInput, HandOutput>::calculate_jacobian));
 }

--- a/test/cpp/modules/manual/LstmTests.cpp
+++ b/test/cpp/modules/manual/LstmTests.cpp
@@ -28,7 +28,7 @@ TEST_P(LstmModuleTest, ObjectiveCalculationCorrectness)
     read_lstm_instance("lstmtest.txt", &input.l, &input.c, &input.b,
         input.main_params, input.extra_params, input.state, input.sequence);
     module->prepare(std::move(input));
-    module->calculateObjective(1);
+    module->calculate_objective(1);
 
     auto output = module->output();
     EXPECT_NEAR(0.66666518, output.objective, 0.000001);
@@ -44,7 +44,7 @@ TEST_P(LstmModuleTest, JacobianCalculationCorrectness)
     read_lstm_instance("lstmtest.txt", &input.l, &input.c, &input.b,
         input.main_params, input.extra_params, input.state, input.sequence);
     module->prepare(std::move(input));
-    module->calculateJacobian(1);
+    module->calculate_jacobian(1);
 
     auto output = module->output();
 
@@ -107,7 +107,7 @@ TEST_P(LstmModuleTest, ObjectiveRunsMultipleTimes)
         input.main_params, input.extra_params, input.state, input.sequence);
     module->prepare(std::move(input));
 
-    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<LSTMInput, LSTMOutput>::calculateObjective));
+    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<LSTMInput, LSTMOutput>::calculate_objective));
 }
 
 TEST_P(LstmModuleTest, JacobianRunsMultipleTimes)
@@ -121,5 +121,5 @@ TEST_P(LstmModuleTest, JacobianRunsMultipleTimes)
         input.main_params, input.extra_params, input.state, input.sequence);
     module->prepare(std::move(input));
 
-    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<LSTMInput, LSTMOutput>::calculateJacobian));
+    EXPECT_TRUE(can_objective_run_multiple_times(*module, &ITest<LSTMInput, LSTMOutput>::calculate_jacobian));
 }

--- a/test/cpp/modules/manual/test_utils.h
+++ b/test/cpp/modules/manual/test_utils.h
@@ -6,7 +6,7 @@
 #include "../../../../src/cpp/runner/Benchmark.h"
 #include "../../../../src/cpp/runner/Filepaths.h"
 
-// Checks whether test_member_function func (calculateObjective or calculateJacobian)
+// Checks whether test_member_function func (calculate_objective or calculate_jacobian)
 // of the provided ITest<Input, Output> instance runs for different time when the supplied
 // times parameter is different. To do so this function uses find_repeats_for_minimum_measurable_time
 // function. It tries to find such a minimum_measurable_time that

--- a/test/cpp/runner/CppRunnerTests.cpp
+++ b/test/cpp/runner/CppRunnerTests.cpp
@@ -28,16 +28,16 @@ TEST(CppRunnerTests, TimeLimit)
     const auto run_count = 100; 
     const auto time_limit = 0.1s;
     //Execution_time should be more than minimum_measurable_time 
-    //because we can expect find_repeats_for_minimum_measurable_time to call calculateObjective function only once in that case.
+    //because we can expect find_repeats_for_minimum_measurable_time to call calculate_objective function only once in that case.
     const auto minimum_measurable_time = 0s;
     const auto execution_time = 0.01s;
 
-    EXPECT_CALL(gmm_test, calculateObjective(_))
+    EXPECT_CALL(gmm_test, calculate_objective(_))
         //Number of runs should be less then run_count variable because total_time will be reached. 
         .Times(testing::AtMost(static_cast<int>(std::ceil(time_limit / execution_time)))) 
         .WillRepeatedly(testing::Invoke([execution_time](auto a) { std::this_thread::sleep_for(execution_time); }));
 
-    measure_shortest_time(minimum_measurable_time, run_count, time_limit, gmm_test, &ITest<GMMInput, GMMOutput>::calculateObjective);
+    measure_shortest_time(minimum_measurable_time, run_count, time_limit, gmm_test, &ITest<GMMInput, GMMOutput>::calculate_objective);
 }
 
 TEST(CppRunnerTests, NumberOfRunsLimit)
@@ -48,11 +48,11 @@ TEST(CppRunnerTests, NumberOfRunsLimit)
     const auto time_limit = 10s;
     const auto execution_time = 0.01s;
     
-    EXPECT_CALL(gmm_test, calculateObjective(_))
+    EXPECT_CALL(gmm_test, calculate_objective(_))
         .Times(testing::Exactly(run_count)) //Number of runs should be equal to run_count limit.
         .WillRepeatedly(testing::Invoke([execution_time](auto a) { std::this_thread::sleep_for(execution_time); }));
 
-    measure_shortest_time(minimum_measurable_time, run_count, time_limit, gmm_test, &ITest<GMMInput, GMMOutput>::calculateObjective);
+    measure_shortest_time(minimum_measurable_time, run_count, time_limit, gmm_test, &ITest<GMMInput, GMMOutput>::calculate_objective);
 }
 
 TEST(CppRunnerTests, TimeMeasurement) 
@@ -63,11 +63,11 @@ TEST(CppRunnerTests, TimeMeasurement)
     const auto time_limit = 100000s;
     const auto execution_time = 0.01s;
 
-    EXPECT_CALL(gmm_test, calculateObjective(_))
+    EXPECT_CALL(gmm_test, calculate_objective(_))
         .Times(testing::Exactly(run_count))
         .WillRepeatedly(testing::Invoke([execution_time](auto a) { std::this_thread::sleep_for(execution_time); }));
 
-    auto shortest_time = measure_shortest_time(minimum_measurable_time, run_count, time_limit, gmm_test, &ITest<GMMInput, GMMOutput>::calculateObjective);
+    auto shortest_time = measure_shortest_time(minimum_measurable_time, run_count, time_limit, gmm_test, &ITest<GMMInput, GMMOutput>::calculate_objective);
 
     ASSERT_GE(shortest_time, execution_time);
 }
@@ -79,11 +79,11 @@ TEST(CppRunnerTests, SearchForRepeats)
     const auto execution_time = 0.01s;
     const auto minimum_measurable_time = execution_time*assumed_repeats;
 
-    EXPECT_CALL(gmm_test, calculateObjective(_))
+    EXPECT_CALL(gmm_test, calculate_objective(_))
         .WillRepeatedly(testing::Invoke([execution_time](auto repeats) { std::this_thread::sleep_for(repeats*execution_time); }));
 
     auto result = find_repeats_for_minimum_measurable_time(minimum_measurable_time, gmm_test,
-                                                           &ITest<GMMInput, GMMOutput>::calculateObjective);
+                                                           &ITest<GMMInput, GMMOutput>::calculate_objective);
 
     ASSERT_NE(result.repeats, measurable_time_not_achieved);
     ASSERT_LE(result.repeats, assumed_repeats);
@@ -94,11 +94,11 @@ TEST(CppRunnerTests, RepeatsNotFound)
     MockGMM gmm_test;
     const auto minimum_measurable_time = 1000s;
 
-    EXPECT_CALL(gmm_test, calculateObjective(_))
+    EXPECT_CALL(gmm_test, calculate_objective(_))
     .Times(AnyNumber());
 
     auto result = find_repeats_for_minimum_measurable_time(minimum_measurable_time, gmm_test,
-                                                           &ITest<GMMInput, GMMOutput>::calculateObjective);
+                                                           &ITest<GMMInput, GMMOutput>::calculate_objective);
 
     ASSERT_EQ(result.repeats, measurable_time_not_achieved);
 }

--- a/test/cpp/runner/MockGMM.cpp
+++ b/test/cpp/runner/MockGMM.cpp
@@ -3,7 +3,7 @@
 
 #include <chrono>
 
-extern "C" DLL_PUBLIC ITest<GMMInput, GMMOutput>* GetGMMTest()
+extern "C" DLL_PUBLIC ITest<GMMInput, GMMOutput>* get_gmm_test()
 {
     return new MockGMM();
 }

--- a/test/cpp/runner/MockGMM.h
+++ b/test/cpp/runner/MockGMM.h
@@ -11,8 +11,8 @@ public:
     void prepare(GMMInput&& input) { prepare(input); }
     MOCK_METHOD1(prepare, void(const GMMInput& input));
 
-    MOCK_METHOD1(calculateObjective, void(int times));
-    MOCK_METHOD1(calculateJacobian, void(int times));
+    MOCK_METHOD1(calculate_objective, void(int times));
+    MOCK_METHOD1(calculate_jacobian, void(int times));
 
     //Returns results of calculation
     MOCK_METHOD0(output, GMMOutput());


### PR DESCRIPTION
- names of external dll functions are converted into snake_case
- names of c++ modules API functions are converted into snake_case