### PR TITLE
Need to include <cctype> for std::toupper and std::isalnum

### DIFF
--- a/src/cpp/runner/main.cpp
+++ b/src/cpp/runner/main.cpp
@@ -1,5 +1,6 @@
 ﻿#include <iostream>
 #include <string>
+#include <cctype>
 
 #include "GMMBenchmark.h"
 #include "BABenchmark.h"

--- a/test/cpp/modules/manual/test_utils.h
+++ b/test/cpp/modules/manual/test_utils.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <string>
 #include <gtest/gtest.h>
+#include <cctype>
 #include "../../../../src/cpp/runner/Benchmark.h"
 #include "../../../../src/cpp/runner/Filepaths.h"
 


### PR DESCRIPTION
I had to include `<cctype>` to get the C++ files to build.  I would be interested to learn how everyone else managed to build them without this include.  Is it perhaps a question of Visual C++ version?