### PR TITLE
Adding markers of incorrect jacobian calculation for graphs

### DIFF
--- a/ADBench/utils.py
+++ b/ADBench/utils.py
@@ -38,10 +38,13 @@ def _set_rec(obj, keys, value, append=False):
 #   ["b1", "file2"]
 #   ["b3", "c", "file3"]
 def _scandir_rec(folder):
-    folder = folder.rstrip("/") + "/"
+    folder = os.path.normpath(folder)
     for fn in os.listdir(folder):
-        if os.path.isdir(folder + fn):
-            yield from ([fn] + file_name for file_name in _scandir_rec(folder + fn))
+        if os.path.isdir(os.path.join(folder, fn)):
+            yield from (
+                [fn] + file_name
+                for file_name in _scandir_rec(os.path.join(folder,fn))
+            )
         else:
             yield [fn]
 
@@ -59,10 +62,13 @@ def _mkdir_if_none(path):
 def cap_str(s):
     return s[0].upper() + (s[1:] if len(s) > 1 else "")
 
+# Remove extension from the file name
+def get_no_ext(file_name):
+    return file_name.split(".")[-2]
 
 # Extract filename (no ext) from path
 def get_fn(path):
-    return path[-1].split(".")[0]
+    return get_no_ext(path[-1])
 
 
 # Extract tool name from filename
@@ -78,11 +84,11 @@ def format_tool(tool):
 
 # Get only non-infinite y-data for a pyplot handle
 def get_non_infinite_y(handle):
-        return get_non_infinite_y_list(handle.get_ydata())
+    return get_non_infinite_y_list(handle.get_ydata())
 
 # Get only non-infinite y-data for a list
 def get_non_infinite_y_list(l):
-        return [y for y in l if y != float("inf")]
+    return  [ y for y in l if y != float("inf") ]
 
 # Extract the test (i.e. type and size) from a filename
 def get_test(fn):

--- a/src/dotnet/utils/JacobianComparisonLib/JacobianComparison.cs
+++ b/src/dotnet/utils/JacobianComparisonLib/JacobianComparison.cs
@@ -63,7 +63,7 @@ namespace JacobianComparisonLib
             if (!File.Exists(path1))
             {
                 this.ParseError = true;
-                this.Error = $"File {path1} doesn't exist.";
+                this.Error = $"File {path1.Replace("\\", "/")} doesn't exist.";
                 return;
             }
             foreach (var path2 in paths2)
@@ -71,7 +71,7 @@ namespace JacobianComparisonLib
                 if (!File.Exists(path2))
                 {
                     this.ParseError = true;
-                    this.Error = $"File {path2} doesn't exist.";
+                    this.Error = $"File {path2.Replace("\\", "/")} doesn't exist.";
                     return;
                 }
             }
@@ -109,14 +109,14 @@ namespace JacobianComparisonLib
             if (!File.Exists(path1))
             {
                 this.ParseError = true;
-                this.Error = $"File {path1} doesn't exist.";
+                this.Error = $"File {path1.Replace("\\", "/")} doesn't exist.";
                 return;
             }
 
             if (!File.Exists(path2))
             {
                 this.ParseError = true;
-                this.Error = $"File {path2} doesn't exist.";
+                this.Error = $"File {path2.Replace("\\", "/")} doesn't exist.";
                 return;
             }
 
@@ -236,7 +236,7 @@ namespace JacobianComparisonLib
                             else
                             {
                                 this.ParseError = true;
-                                this.Error = $"Failed to parse file {path} - line {curLine} position {lastNumStartPos}.";
+                                this.Error = $"Failed to parse file {path.Replace("\\", "/")} - line {curLine} position {lastNumStartPos}.";
                                 yield return Token.CreateError();
                                 yield break;
                             }
@@ -277,7 +277,7 @@ namespace JacobianComparisonLib
                     else
                     {
                         this.ParseError = true;
-                        this.Error = $"Failed to parse file {path} - line {curLine} position {lastNumStartPos}.";
+                        this.Error = $"Failed to parse file {path.Replace("\\", "/")} - line {curLine} position {lastNumStartPos}.";
                         yield return Token.CreateError();
                     }
                 }
@@ -297,7 +297,7 @@ namespace JacobianComparisonLib
                 else
                 {
                     this.ParseError = true;
-                    this.Error = $"Failed to parse file {path} - line {line} index {curLine}.";
+                    this.Error = $"Failed to parse file {path.Replace("\\", "/")} - line {line} index {curLine}.";
                     result = null;
                     return false;
                 }
@@ -320,7 +320,7 @@ namespace JacobianComparisonLib
                 else
                 {
                     this.ParseError = true;
-                    this.Error = $"Failed to parse file {path} - line {line} index {curLine}.";
+                    this.Error = $"Failed to parse file {path.Replace("\\", "/")} - line {line} index {curLine}.";
                     result = null;
                     return false;
                 }


### PR DESCRIPTION
1. New kind of markers, which show that jacobian calculation was incorrect, is added to graphs.
2. The source of `plot_graohs.py` is refactored. Moreover now it uses crossplatform utils from `os.path` for file and folder paths handling.
3. JSON generating by JacobianComparision util is repaired (now it is set paths in Error field value without backslashes).

## Examples of graphs:
<img width="864" alt="BA  Jacobian  - Release Graph" src="https://user-images.githubusercontent.com/40039815/65378444-16278b80-dcc1-11e9-8652-7ce7729afb22.png">
Note: now if a tool is terminated in all points, suffix "all crashed/terminated" is added to the legend.

<img width="864" alt="BA  Objective  - Release Graph" src="https://user-images.githubusercontent.com/40039815/65378467-6272cb80-dcc1-11e9-9823-1f027efff9e1.png">
Note: if there was only one non-crashed point, then in the last version you couldn't distinguish on which line black dot lied. Now you can.

<img width="864" alt="GMM (10k)  Jacobian  - Release Graph" src="https://user-images.githubusercontent.com/40039815/65378488-b1b8fc00-dcc1-11e9-9832-f2ddf54bc767.png">