### PR TITLE
Toelli/graph correctness main

### DIFF
--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -26,6 +26,7 @@ TIMES_SUBSTRING = "times"
 CORRECTNESS_SUBSTRING = "correctness"
 
 VIOLATION_LABEL = "Wrong calculation result"
+TERMINATED_LABEL = "Crashed/Terminated"
 ALL_TERMINATED_SUFFIX = " (all crashed/terminated)"
 
 figure_size = (9, 6) if do_plotly else (12, 8)
@@ -322,8 +323,8 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
 
     # Add handle for black dots if it necessary
     if len(failed_x) > 0:
-        handles += tuple(pyplot.plot(failed_x, failed_y, marker="o", color="k", linestyle="None", label="Crashed/Terminated"))
-        labels += ("Crashed/Terminated",)
+        handles += tuple(pyplot.plot(failed_x, failed_y, marker="o", color="k", linestyle="None", label=TERMINATED_LABEL))
+        labels += (TERMINATED_LABEL,)
 
     # Add handle for violation if it necessary
     if violation_handle != None:

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -137,17 +137,23 @@ def read_vals(objective, graph_files, tool):
 
     # Extract times
     name_to_n = utils.key_functions[objective]
-    time_pairs = [(name_to_n(utils.get_test(os.path.splitext(os.path.split(path)[1])[0])),
-                   utils.read_times(os.path.join(in_dir, path)))
-                  for path in tool_files]
+    info = [
+        (
+            name_to_n(utils.get_test(os.path.splitext(os.path.split(tool_files[i])[1])[0])),
+            utils.read_times(os.path.join(in_dir, tool_files[i])),
+            violation_info[i]
+        )
+        for i in range(len(tool_files))
+    ]
 
     # Sort values
-    times_sorted = sorted(time_pairs, key=lambda pair: pair[0])
-    n_vals = list(map(lambda pair: pair[0], times_sorted))
-    t_objective_vals = list(map(lambda pair: pair[1][0], times_sorted))
-    t_jacobian_vals = list(map(lambda pair: pair[1][1], times_sorted))
+    info_sorted = sorted(info, key=lambda triple: triple[0])
+    n_vals = list(map(lambda triple: triple[0], info_sorted))
+    t_objective_vals = list(map(lambda triple: triple[1][0], info_sorted))
+    t_jacobian_vals = list(map(lambda triple: triple[1][1], info_sorted))
+    violation_vals = list(map(lambda triple: triple[2], info_sorted))
 
-    return (n_vals, t_objective_vals, t_jacobian_vals, violation_info)
+    return (n_vals, t_objective_vals, t_jacobian_vals, violation_vals)
 
 def vals_by_tool(objective, graph_files):
     '''Classifies file values by tools'''

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -22,8 +22,8 @@ if do_show:
     print("WARNING: `--show` enabled. This script can produce a lot of graphs and you may not wish to display all of them.\n")
 
 # Script constants
-TIMES_SUBSTRING = "times"
-CORRECTNESS_SUBSTRING = "correctness"
+TIMES_SUBSTRING = "_times_"
+CORRECTNESS_SUBSTRING = "_correctness_"
 
 VIOLATION_LABEL = "Wrong calculation result"
 TERMINATED_LABEL = "Crashed/Terminated"

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -266,8 +266,7 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
         )
 
         # if there was calculating violations
-        # or crash/timeout
-        if any(violations) or inf_inds:
+        if any(violations):
             # Set markers for correct and incorrect points
             incorr_mark_list = []
             for i in range(len(n_vals)):

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -261,59 +261,59 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
         # or crash/timeout
         if any(violations) or inf_inds:
             # Set markers for correct and incorrect points
-            corr_mark_list, incorr_mark_list = [], []
+            incorr_mark_list = []
             for i in range(len(n_vals)):
-                if i not in inf_inds:
-                    if violations[i]:
-                        incorr_mark_list.append(i)
-                    else:
-                        corr_mark_list.append(i)
+                if i not in inf_inds and violations[i]:
+                    incorr_mark_list.append(i)
 
             handles += pyplot.plot(
                 n_vals,
                 t_vals,
                 marker=marker,
                 color=color,
-                label=utils.format_tool(tool),
-                markevery=corr_mark_list
+                label=utils.format_tool(tool)
             )
 
             if incorr_mark_list:
-                # handle cases when there is a single point with violation
-                # between timeout gaps
-                # (then writing additional line marker to distinguish a line)
-                additional_mark_idx = []
-                for i in range(len(incorr_mark_list)):
-                    idx = incorr_mark_list[i]
-                    is_single = (
-                        ( # check left
-                            idx == 0 or
-                            idx - 1 not in incorr_mark_list and
-                            idx - 1 in inf_inds
+                if not do_plotly:
+                    # handle cases when there is a single point with violation
+                    # between timeout gaps
+                    # (then write additional line marker to distinguish a line.
+                    # In plotly scenario it is not necessary because user
+                    # can turn violation marker off and see the marker of the
+                    # line)
+                    additional_mark_idx = []
+                    for i in range(len(incorr_mark_list)):
+                        idx = incorr_mark_list[i]
+                        is_single = (
+                            ( # check left
+                                idx == 0 or
+                                idx - 1 not in incorr_mark_list and
+                                idx - 1 in inf_inds
+                            )
+                            and
+                            ( # check right
+                                idx == len(n_vals) - 1 or
+                                idx + 1 not in incorr_mark_list and
+                                idx + 1 in inf_inds
+                            )
                         )
-                        and
-                        ( # check right
-                            idx == len(n_vals) - 1 or
-                            idx + 1 not in incorr_mark_list and
-                            idx + 1 in inf_inds
+
+                        if is_single:
+                            additional_mark_idx.append(idx)
+
+                    if additional_mark_idx:
+                        x_vals = [ n_vals[idx] for idx in additional_mark_idx ]
+                        y_vals = [ t_vals[idx] for idx in additional_mark_idx ]
+                        pyplot.plot(
+                            x_vals,
+                            y_vals,
+                            linestyle="None",
+                            marker="_",
+                            ms=17,
+                            mew=2,
+                            color=color
                         )
-                    )
-
-                    if is_single:
-                        additional_mark_idx.append(idx)
-
-                if additional_mark_idx:
-                    x_vals = [ n_vals[idx] for idx in additional_mark_idx ]
-                    y_vals = [ t_vals[idx] for idx in additional_mark_idx ]
-                    pyplot.plot(
-                        x_vals,
-                        y_vals,
-                        linestyle="None",
-                        marker="_",
-                        ms=17,
-                        mew=2,
-                        color=color
-                    )
                 
                 # drawing violation markers
                 violation_handle = pyplot.plot(

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -236,7 +236,7 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
     lines = zip(all_styles, sorted_vals_by_tool)
 
     handles, labels = [], []
-    failed_x, failed_y = [], []
+    violation_x, violation_y = [], []
     violation_handle = None
 
     # Plot results
@@ -315,18 +315,11 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
                             color=color
                         )
                 
-                # drawing violation markers
-                violation_handle = pyplot.plot(
-                    n_vals,
-                    t_vals,
-                    marker="v",
-                    mec="k",
-                    mfc="r",
-                    ms=8,
-                    linestyle="None",
-                    label=VIOLATION_LABEL,
-                    markevery=incorr_mark_list
-                )
+                # adding violation point coordinates
+                for idx in incorr_mark_list:
+                    violation_x.append(n_vals[idx])
+                    violation_y.append(t_vals[idx])
+                
         else:
             handles += pyplot.plot(
                 n_vals,
@@ -336,9 +329,19 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
                 label=utils.format_tool(tool)
             )
 
-    # Add handle for violation if it necessary
-    if violation_handle != None:
-        handles += violation_handle
+    # if there was calculating violation add violation markers
+    if violation_x:
+        handles += pyplot.plot(
+            violation_x,
+            violation_y,
+            marker="v",
+            mec="k",
+            mfc="r",
+            ms=8,
+            linestyle="None",
+            label=VIOLATION_LABEL
+        )
+
         labels.append(VIOLATION_LABEL)
 
     # Setup graph attributes

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -237,6 +237,7 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
 
     handles, labels = [], []
     violation_x, violation_y = [], []
+    additional_x, additional_y, additional_colors = [], [], []
     violation_handle = None
 
     # Plot results
@@ -275,7 +276,7 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
             )
 
             if incorr_mark_list:
-                if not do_plotly:
+                if do_save or do_show:
                     # handle cases when there is a single point with violation
                     # between timeout gaps
                     # (then write additional line marker to distinguish a line.
@@ -302,18 +303,19 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
                         if is_single:
                             additional_mark_idx.append(idx)
 
+                    # addint coordinates of additional markers
                     if additional_mark_idx:
-                        x_vals = [ n_vals[idx] for idx in additional_mark_idx ]
-                        y_vals = [ t_vals[idx] for idx in additional_mark_idx ]
-                        pyplot.plot(
-                            x_vals,
-                            y_vals,
-                            linestyle="None",
-                            marker="_",
-                            ms=17,
-                            mew=2,
-                            color=color
-                        )
+                        additional_x.append([
+                            n_vals[idx]
+                            for idx in additional_mark_idx
+                        ])
+                        
+                        additional_y.append([
+                            t_vals[idx]
+                            for idx in additional_mark_idx
+                        ])
+
+                        additional_colors.append(color)
                 
                 # adding violation point coordinates
                 for idx in incorr_mark_list:
@@ -365,6 +367,21 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
 
     # Add legend (after plotly to avoid error)
     pyplot.legend(handles, labels, loc=4, bbox_to_anchor=(1, 0))
+
+    # draw additional markers
+    # Note: we do this later than plotly converting because plotly doesn't
+    #       need additional markers
+    for x, y, color in zip(additional_x, additional_y, additional_colors):
+        pyplot.plot(
+            x,
+            y,
+            linestyle="None",
+            marker="_",
+            ms=17,
+            mew=2,
+            color=color,
+            zorder=0
+        )
 
     # Save graph (if selected)
     if do_save:

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -262,7 +262,7 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
             t_vals,
             marker=marker,
             color=color,
-            label=utils.format_tool(tool)
+            label=label
         )
 
         # if there was calculating violations

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -257,6 +257,13 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
             label += ALL_TERMINATED_SUFFIX
 
         labels.append(label)
+        handles += pyplot.plot(
+            n_vals,
+            t_vals,
+            marker=marker,
+            color=color,
+            label=utils.format_tool(tool)
+        )
 
         # if there was calculating violations
         # or crash/timeout
@@ -266,14 +273,6 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
             for i in range(len(n_vals)):
                 if i not in inf_inds and violations[i]:
                     incorr_mark_list.append(i)
-
-            handles += pyplot.plot(
-                n_vals,
-                t_vals,
-                marker=marker,
-                color=color,
-                label=utils.format_tool(tool)
-            )
 
             if incorr_mark_list:
                 if do_save or do_show:
@@ -321,15 +320,6 @@ for (figure_idx, (graph, function_type)) in enumerate(all_graphs, start=1):
                 for idx in incorr_mark_list:
                     violation_x.append(n_vals[idx])
                     violation_y.append(t_vals[idx])
-                
-        else:
-            handles += pyplot.plot(
-                n_vals,
-                t_vals,
-                marker=marker,
-                color=color,
-                label=utils.format_tool(tool)
-            )
 
     # if there was calculating violation add violation markers
     if violation_x:

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -77,7 +77,7 @@ has_manual = lambda tool: tool.lower() in ["manual", "manual_eigen"]
 def tool_names(graph_files):
     '''Returns a set of tool names from all calculated files.'''
 
-    file_names = map(utils.get_fn, graph_files)
+    file_names = map(lambda path: os.path.splitext(path[-1])[0], graph_files)
     tool_names_ = set(map(utils.get_tool, file_names))
 
     # Sort "Manual" to the front
@@ -122,7 +122,7 @@ def read_vals(objective, graph_files, tool):
             print(msg)
             return False
 
-    tool_files = [os.path.join(*path) for path in graph_files if utils.get_tool(utils.get_fn(path)) == tool]
+    tool_files = [os.path.join(*path) for path in graph_files if utils.get_tool(os.path.splitext(path[-1])[0]) == tool]
 
     if has_manual(tool):
         violation_info = [
@@ -137,7 +137,7 @@ def read_vals(objective, graph_files, tool):
 
     # Extract times
     name_to_n = utils.key_functions[objective]
-    time_pairs = [(name_to_n(utils.get_test(utils.get_no_ext(os.path.split(path)[1]))),
+    time_pairs = [(name_to_n(utils.get_test(os.path.splitext(os.path.split(path)[1])[0])),
                    utils.read_times(os.path.join(in_dir, path)))
                   for path in tool_files]
 

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -22,6 +22,7 @@ if do_show:
     print("WARNING: `--show` enabled. This script can produce a lot of graphs and you may not wish to display all of them.\n")
 
 # Script constants
+TIMES_SUBSTRING = "times"
 CORRECTNESS_SUBSTRING = "correctness"
 
 VIOLATION_LABEL = "Wrong calculation result"
@@ -49,7 +50,7 @@ print(f"Output directory is: {out_dir}\n")
 
 
 # Scan folder for all files, and determine which graphs to create
-all_files = [path for path in utils._scandir_rec(in_dir) if "times" in path[-1]]
+all_files = [path for path in utils._scandir_rec(in_dir) if TIMES_SUBSTRING in path[-1]]
 all_graphs = [path.split("/") for path in set(["/".join(path[:-2]) for path in all_files])]
 function_types = ["objective ÷ Manual", "objective", "jacobian", "jacobian ÷ objective"]
 all_graphs = [(path, function_type) for function_type in function_types for path in all_graphs]
@@ -95,7 +96,7 @@ def read_vals(objective, graph_files, tool):
         correctness_file_name = os.path.join(
             in_dir,
             folder,
-            fn.replace("times", CORRECTNESS_SUBSTRING)
+            fn.replace(TIMES_SUBSTRING, CORRECTNESS_SUBSTRING)
         )
 
         if not os.path.isfile(correctness_file_name):

--- a/ADBench/utils.py
+++ b/ADBench/utils.py
@@ -59,10 +59,13 @@ def _mkdir_if_none(path):
 def cap_str(s):
     return s[0].upper() + (s[1:] if len(s) > 1 else "")
 
+# Remove extension from the file name
+def get_no_ext(file_name):
+    return file_name.split(".")[-2]
 
 # Extract filename (no ext) from path
 def get_fn(path):
-    return path[-1].split(".")[0]
+    return get_no_ext(path[-1])
 
 
 # Extract tool name from filename
@@ -82,7 +85,7 @@ def get_non_infinite_y(handle):
 
 # Get only non-infinite y-data for a list
 def get_non_infinite_y_list(l):
-    return [y for y in l if y != float("inf")]
+    return  [ y for y in l if y != float("inf") ]
 
 # Extract the test (i.e. type and size) from a filename
 def get_test(fn):

--- a/ADBench/utils.py
+++ b/ADBench/utils.py
@@ -59,14 +59,6 @@ def _mkdir_if_none(path):
 def cap_str(s):
     return s[0].upper() + (s[1:] if len(s) > 1 else "")
 
-# Remove extension from the file name
-def get_no_ext(file_name):
-    return os.path.splitext(file_name)[0]
-
-# Extract filename (no ext) from path
-def get_fn(path):
-    return get_no_ext(path[-1])
-
 
 # Extract tool name from filename
 def get_tool(fn):

--- a/ADBench/utils.py
+++ b/ADBench/utils.py
@@ -61,7 +61,7 @@ def cap_str(s):
 
 # Remove extension from the file name
 def get_no_ext(file_name):
-    return file_name.split(".")[-2]
+    return os.path.splitext(file_name)[0]
 
 # Extract filename (no ext) from path
 def get_fn(path):


### PR DESCRIPTION
This PR contains a bulk of PR #94 with additional changes:
- Black dots are removed
- All violation markers have the same handle (make sense for plotly)
- For static graphs and show mode additional marker for a single point between gaps (timeouts) when it has violation is added. It helps to distingush which line the violation marker belongs to. These markers are not added for plotly becuase they are unnecessary there: user can turn violation markers off and see the real marker of the line which was hideen by the violation marker

# Graph examples
## Static
<img width="648" alt="GMM (1k)  Jacobian  - Release Graph" src="https://user-images.githubusercontent.com/40039815/65620740-0b277080-dfcb-11e9-9f6b-019d01fa3033.png">
<img width="648" alt="BA  Jacobian  - Release Graph" src="https://user-images.githubusercontent.com/40039815/65620741-0b277080-dfcb-11e9-9b83-f0ea1cd69aab.png">

## Plotly
![image](https://user-images.githubusercontent.com/40039815/65620680-efbc6580-dfca-11e9-8412-e2f039260e4b.png)
![image](https://user-images.githubusercontent.com/40039815/65620809-2c885c80-dfcb-11e9-8dc4-dd40c891877b.png)

![image](https://user-images.githubusercontent.com/40039815/65620706-fba82780-dfca-11e9-9e38-2451acd0b6e5.png)
![image](https://user-images.githubusercontent.com/40039815/65620878-52156600-dfcb-11e9-9bf1-2846ee8312bf.png)
