### PR TITLE
Use ASCII encoding for correctness files

### DIFF
--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -104,7 +104,7 @@ def read_vals(objective, graph_files, tool):
             return False
 
         try:
-            with open(correctness_file_name, "r", encoding="utf-16") as cf:
+            with open(correctness_file_name, "r", encoding="ascii") as cf:
                 correctness_data = json.load(cf)
                 return correctness_data["ViolationsHappened"]
         except Exception as e:

--- a/ADBench/run-all.ps1
+++ b/ADBench/run-all.ps1
@@ -354,7 +354,7 @@ Class Tool {
             $golden_jacobian_path = "${dir_out}../$([Tool]::golden_tool_name)/${fn}_J_$([Tool]::golden_tool_name).txt"
             $comparison = New-JacobianComparison $this.result_check_tolerance
             $comparison.CompareFiles($current_jacobian_path, $golden_jacobian_path)
-            $comparison.ToJsonString() | Out-File "${dir_out}${fn}_correctness_${out_name}.txt"
+            $comparison.ToJsonString() | Out-File "${dir_out}${fn}_correctness_${out_name}.txt" -encoding ASCII
             if ($comparison.ViolationsHappened()) {
                 Write-Host "          Discrepancies with the correct jacobian found. See ${dir_out}${fn}_correctness_${out_name}.txt for details."
             }


### PR DESCRIPTION
Fixes: https://github.com/awf/ADBench/issues/124