### PR TITLE
Style mapping

### DIFF
--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -45,7 +45,7 @@ all_styles = {
 
     # Python tools
     "PyTorch": ("g", "s", "Python, PyTorch"),
-    "Tensorflow": ("r", "s", "Python, Tensorflow (eager execution)"),
+    "Tensorflow": ("r", "s", "Python, Tensorflow"),
     "Autograd": ("c", "s", "Python, Autograd"),
 
     # Julia tools

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -29,9 +29,28 @@ ALL_TERMINATED_SUFFIX = " (all crashed/terminated)"
 figure_size = (9, 6) if do_plotly else (12, 8)
 fig_dpi = 96
 save_dpi = 144
-colors = ["b", "g", "r", "c", "m", "y"]
-markers = ["*", "+", "s", "^"]
-all_styles = [(c, m) for m in markers for c in colors]
+
+all_styles = {
+    # C++ tools
+    "Finite": ("b", "*"),
+    "FiniteEigen": ("g", "*"),
+    "Manual": ("r", "*"),
+    "ManualEigen": ("c", "*"),
+    "ManualEigenVector": ("m", "*"),
+    "Tapenade": ("y", "*"),
+
+    # .Net tools
+    "DiffSharp": ("b", "o"),
+
+    # Python tools
+    "PyTorch": ("g", "s"),
+    "Tensorflow": ("r", "s"),
+    "Autograd": ("c", "s"),
+
+    # Julia tools
+    "Julia": ("m", "v"),
+    "Zygote": ("y", "v")
+}
 
 # Folders
 adbench_dir = os.path.dirname(os.path.realpath(__file__))
@@ -292,15 +311,15 @@ def generate_graph(figure_idx, graph_function_type):
 
     sorted_vals_by_tool = get_sorted_vals_by_tool(objective, graph, function_type)
 
-    lines = zip(all_styles, sorted_vals_by_tool)
-
     handles, labels = [], []
     violation_x, violation_y = [], []
     was_violation = False
     additional = []
 
     # Plot results
-    for ((color, marker), (tool, n_vals, t_vals, violations)) in lines:
+    for (tool, n_vals, t_vals, violations) in sorted_vals_by_tool:
+        color, marker = all_styles[tool]
+
         (label, handle) = label_and_handle(tool, n_vals, t_vals, (color, marker))
         (together, additionals) = together_and_additionals(n_vals, t_vals, violations)
 

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -34,15 +34,15 @@ save_dpi = 144
 default_styles = [ (color, "x") for color in "rgbcmyk" ]
 tool_styles = {
     # C++ tools
-    "Finite": ("b", "*", "C++, Finite"),
-    "FiniteEigen": ("g", "*", "C++, Finite Eigen"),
-    "Manual": ("r", "*", "C++, Manual"),
-    "ManualEigen": ("c", "*", "C++, Manual Eigen"),
-    "ManualEigenVector": ("m", "*", "C++, Manual Eigen Vector"),
+    "Finite": ("b", "o", "C++, Finite"),
+    "FiniteEigen": ("b", "s", "C++, Finite Eigen"),
+    "Manual": ("k", "o", "C++, Manual"),
+    "ManualEigen": ("k", "s", "C++, Manual Eigen"),
+    "ManualEigenVector": ("k", "D", "C++, Manual Eigen Vector"),
     "Tapenade": ("y", "*", "C, Tapenade"),
 
     # .Net tools
-    "DiffSharp": ("b", "o", "F#, DiffSharp"),
+    "DiffSharp": ("grey", "D", "F#, DiffSharp"),
 
     # Python tools
     "PyTorch": ("g", "s", "Python, PyTorch"),

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -42,7 +42,7 @@ tool_styles = {
     "Tapenade": ("y", "*", "C, Tapenade"),
 
     # .Net tools
-    "DiffSharp": ("b", "o", ".Net, DiffSharp"),
+    "DiffSharp": ("b", "o", "F#, DiffSharp"),
 
     # Python tools
     "PyTorch": ("g", "s", "Python, PyTorch"),

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -276,28 +276,44 @@ both neighbours missing'''
 
     return (together, additionals)
 
-def label_and_handle(tool, n_vals, t_vals, style):
+def label_and_handle(tool, n_vals, t_vals, style, disp_name):
     '''Returns (label, handle)
 
 where label is the label that should be used in the legend for this
 tool and handle is a handle to the plotted data for this tool'''
 
-    (color, marker) = style[0: 2]
-    label = utils.format_tool(tool) if len(style) == 2 else style[2]
+    color, marker = style
     all_terminated = all(t_val == float("inf") for t_val in t_vals)
+
     # Append label in legend if all point values are infinite
     if all_terminated:
-        label += ALL_TERMINATED_SUFFIX
+        disp_name += ALL_TERMINATED_SUFFIX
 
     handle = pyplot.plot(
         n_vals,
         t_vals,
         marker=marker,
         color=color,
-        label=label
+        label=disp_name
     )
 
-    return (label, handle)
+    return (disp_name, handle)
+
+def values_and_styles(sorted_vals_by_tool):
+    '''Returns generator for tool values concatenated with tool style and
+    display name: (values, style, display_name).'''
+
+    for item in sorted_vals_by_tool:
+        tool = item[0]
+        if tool in all_styles:
+            style = all_styles[tool][0: 2]
+        else:
+            style = default_style
+            print(f'WARNING: style is not specified for tool "{tool}"! Default style is used')
+
+        display_name = utils.format_tool(tool) if len(style) == 2 else style[2]
+
+        yield item, style, display_name
 
 def generate_graph(figure_idx, graph_function_type):
     '''Generates the graph for the pair graph_function_type of graph and function_type'''
@@ -317,14 +333,8 @@ def generate_graph(figure_idx, graph_function_type):
     additional = []
 
     # Plot results
-    for (tool, n_vals, t_vals, violations) in sorted_vals_by_tool:
-        if tool in all_styles:
-            style = all_styles[tool]
-        else:
-            style = default_style
-            print(f'WARNING: style is not specified for tool "{tool}"! Default style is used')
-
-        (label, handle) = label_and_handle(tool, n_vals, t_vals, style)
+    for ((tool, n_vals, t_vals, violations), style, disp_name) in values_and_styles(sorted_vals_by_tool):
+        (label, handle) = label_and_handle(tool, n_vals, t_vals, style, disp_name)
         (together, additionals) = together_and_additionals(n_vals, t_vals, violations)
 
         labels.append(label)

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -30,7 +30,8 @@ figure_size = (9, 6) if do_plotly else (12, 8)
 fig_dpi = 96
 save_dpi = 144
 
-default_style = ("k", "x")  # for tools that have no mapped style
+# for tools that have no mapped style
+default_styles = [ (color, "x") for color in "rgbcmyk" ]
 tool_styles = {
     # C++ tools
     "Finite": ("b", "*", "C++, Finite"),
@@ -303,13 +304,15 @@ def values_and_styles(sorted_vals_by_tool):
     '''Returns generator for tool values concatenated with tool style and
     display name: (values, style, display_name).'''
 
+    next_default = 0
     for item in sorted_vals_by_tool:
         tool = item[0]
         if tool in tool_styles:
             style = tool_styles[tool][0: 2]
         else:
-            style = default_style
-            print(f'WARNING: style is not specified for tool "{tool}"! Default style is used')
+            style = default_styles[next_default]
+            next_default = (next_default + 1) % len(default_styles)
+            print(f'WARNING: style is not specified for tool "{tool}"! One of default styles is used')
 
         display_name = utils.format_tool(tool) if len(style) == 2 else style[2]
 

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -30,6 +30,7 @@ figure_size = (9, 6) if do_plotly else (12, 8)
 fig_dpi = 96
 save_dpi = 144
 
+default_style = ("k", "x")  # for tools that have no mapped style
 all_styles = {
     # C++ tools
     "Finite": ("b", "*"),
@@ -318,7 +319,11 @@ def generate_graph(figure_idx, graph_function_type):
 
     # Plot results
     for (tool, n_vals, t_vals, violations) in sorted_vals_by_tool:
-        color, marker = all_styles[tool]
+        if tool in all_styles:
+            color, marker = all_styles[tool]
+        else:
+            color, marker = default_style
+            print(f'WARNING: style is not specified for tool "{tool}"! Default style is used')
 
         (label, handle) = label_and_handle(tool, n_vals, t_vals, (color, marker))
         (together, additionals) = together_and_additionals(n_vals, t_vals, violations)

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -31,7 +31,7 @@ fig_dpi = 96
 save_dpi = 144
 
 default_style = ("k", "x")  # for tools that have no mapped style
-all_styles = {
+tool_styles = {
     # C++ tools
     "Finite": ("b", "*", "C++, Finite"),
     "FiniteEigen": ("g", "*", "C++, Finite Eigen"),
@@ -305,8 +305,8 @@ def values_and_styles(sorted_vals_by_tool):
 
     for item in sorted_vals_by_tool:
         tool = item[0]
-        if tool in all_styles:
-            style = all_styles[tool][0: 2]
+        if tool in tool_styles:
+            style = tool_styles[tool][0: 2]
         else:
             style = default_style
             print(f'WARNING: style is not specified for tool "{tool}"! Default style is used')

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -308,7 +308,7 @@ def values_and_styles(sorted_vals_by_tool):
     for item in sorted_vals_by_tool:
         tool = item[0]
         if tool in tool_styles:
-            style = tool_styles[tool][0: 2]
+            style = tool_styles[tool]
         else:
             style = default_styles[next_default]
             next_default = (next_default + 1) % len(default_styles)
@@ -316,7 +316,7 @@ def values_and_styles(sorted_vals_by_tool):
 
         display_name = utils.format_tool(tool) if len(style) == 2 else style[2]
 
-        yield item, style, display_name
+        yield item, style[0: 2], display_name
 
 def generate_graph(figure_idx, graph_function_type):
     '''Generates the graph for the pair graph_function_type of graph and function_type'''

--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -33,24 +33,23 @@ save_dpi = 144
 default_style = ("k", "x")  # for tools that have no mapped style
 all_styles = {
     # C++ tools
-    "Finite": ("b", "*"),
-    "FiniteEigen": ("g", "*"),
-    "Manual": ("r", "*"),
-    "ManualEigen": ("c", "*"),
-    "ManualEigenVector": ("m", "*"),
-    "Tapenade": ("y", "*"),
+    "Finite": ("b", "*", "C++, Finite"),
+    "FiniteEigen": ("g", "*", "C++, Finite Eigen"),
+    "Manual": ("r", "*", "C++, Manual"),
+    "ManualEigen": ("c", "*", "C++, Manual Eigen"),
+    "ManualEigenVector": ("m", "*", "C++, Manual Eigen Vector"),
+    "Tapenade": ("y", "*", "C, Tapenade"),
 
     # .Net tools
-    "DiffSharp": ("b", "o"),
+    "DiffSharp": ("b", "o", ".Net, DiffSharp"),
 
     # Python tools
-    "PyTorch": ("g", "s"),
-    "Tensorflow": ("r", "s"),
-    "Autograd": ("c", "s"),
+    "PyTorch": ("g", "s", "Python, PyTorch"),
+    "Tensorflow": ("r", "s", "Python, Tensorflow (eager execution)"),
+    "Autograd": ("c", "s", "Python, Autograd"),
 
     # Julia tools
-    "Julia": ("m", "v"),
-    "Zygote": ("y", "v")
+    "Zygote": ("y", "v", "Julia, Zygote")
 }
 
 # Folders
@@ -277,14 +276,14 @@ both neighbours missing'''
 
     return (together, additionals)
 
-def label_and_handle(tool, n_vals, t_vals, color_marker):
+def label_and_handle(tool, n_vals, t_vals, style):
     '''Returns (label, handle)
 
 where label is the label that should be used in the legend for this
 tool and handle is a handle to the plotted data for this tool'''
 
-    (color, marker) = color_marker
-    label = utils.format_tool(tool)
+    (color, marker) = style[0: 2]
+    label = utils.format_tool(tool) if len(style) == 2 else style[2]
     all_terminated = all(t_val == float("inf") for t_val in t_vals)
     # Append label in legend if all point values are infinite
     if all_terminated:
@@ -320,12 +319,12 @@ def generate_graph(figure_idx, graph_function_type):
     # Plot results
     for (tool, n_vals, t_vals, violations) in sorted_vals_by_tool:
         if tool in all_styles:
-            color, marker = all_styles[tool]
+            style = all_styles[tool]
         else:
-            color, marker = default_style
+            style = default_style
             print(f'WARNING: style is not specified for tool "{tool}"! Default style is used')
 
-        (label, handle) = label_and_handle(tool, n_vals, t_vals, (color, marker))
+        (label, handle) = label_and_handle(tool, n_vals, t_vals, style)
         (together, additionals) = together_and_additionals(n_vals, t_vals, violations)
 
         labels.append(label)
@@ -334,7 +333,7 @@ def generate_graph(figure_idx, graph_function_type):
         # adding coordinates of additional markers
         additional.append(([n_val for (n_val, _) in additionals],
                            [t_val for (_, t_val) in additionals],
-                           color))
+                           style[0]))
 
         violation_x += [n_val for (n_val, _, _, _, violation)
                         in together if violation]


### PR DESCRIPTION
Styles are hard linked to tools by map. For each new tool respected style must be added to the map. If tool style is not specified, default style will be used. Map has the following form:
```Python
all_styles = {
    <tool name>: (<color>, <marker> [,<optional displaying name of the tool>]),
    ...
}
```
Using the same marks for the tools of the same language/platform is suggested.

# Plot examples
## Static
<img width="648" alt="BA  Jacobian  - Release Graph" src="https://user-images.githubusercontent.com/40039815/66859515-29620a00-ef94-11e9-8ab8-68c1bfbd2742.png">
<img width="648" alt="GMM (1k)  Jacobian ÷ objective  - Release Graph" src="https://user-images.githubusercontent.com/40039815/66859526-2e26be00-ef94-11e9-825b-e4662e48a104.png">
<img width="648" alt="HAND (Complicated, Big)  Objective  - Release Graph" src="https://user-images.githubusercontent.com/40039815/66859539-3252db80-ef94-11e9-87bb-b3ad4dc4479b.png">
<img width="648" alt="LSTM  Objective ÷ manual  - Release Graph" src="https://user-images.githubusercontent.com/40039815/66859550-35e66280-ef94-11e9-83e4-fc7bfe8cda27.png">


## Plotly
![image](https://user-images.githubusercontent.com/40039815/66859227-90cb8a00-ef93-11e9-990f-a931b94d9b42.png)


