### PR TITLE
Add line ending after writing times and value

### DIFF
--- a/src/cpp/runner/OutputSave.cpp
+++ b/src/cpp/runner/OutputSave.cpp
@@ -18,7 +18,7 @@ void save_time_to_file(const std::string& filepath, const double objective_time,
 {
     std::ofstream out(filepath);
 
-    out << std::scientific << objective_time << std::endl << derivative_time;
+    out << std::scientific << objective_time << std::endl << derivative_time << std::endl;
     out.close();
 }
 
@@ -26,7 +26,7 @@ void save_value_to_file(const std::string& filepath, const double& value)
 {
     precise_ofstream<std::remove_reference_t<decltype(value)>> out(filepath);
 
-    out << value;
+    out << value << std::endl;
     out.close();
 }
 


### PR DESCRIPTION
I don't know any reason why it would break things to add a new line, but having them improves the user experience of trying to view the files.