### PR TITLE
Run all tool process in Azure Batch

### DIFF
--- a/ADBench/AzureBatch/runallscript.sh
+++ b/ADBench/AzureBatch/runallscript.sh
@@ -18,6 +18,8 @@ DOCKER_INSTALLATION_PROBLEM_EXIT_CODE=3
 DOCKER_ACTIVATING_PROBLEM_EXIT_CODE=4
 DOCKER_BUILD_PROBLEM_EXIT_CODE=5
 TEST_FAIL_EXIT_CODE=6
+TOOL_RUNNING_FAILURE_EXIT_CODE=7
+PLOT_CREATING_FAILURE_EXIT_CODE=8
 
 
 
@@ -118,8 +120,23 @@ mkdir tmp
 # Run all tools.
 docker run -v $(pwd)/tmp:/adb/tmp/ adb-docker -r
 
+# Check tool running.
+# Note: run-all.ps1 script returns "8" in case of non-fatal errors.
+if [[ $? -ne 0 && $? -ne 8 ]]
+then
+    echo "Running all tools failure! Stopping the script"
+    exit $TOOL_RUNNING_FAILURE_EXIT_CODE
+fi
+
 # Create plots.
 docker run -v $(pwd)/tmp:/adb/tmp/ adb-docker -p --save --plotly
+
+# Check plot creating.
+if [[ $? -ne 0 ]]
+then
+    echo "Plot creating failure! Stopping the script"
+    exit $PLOT_CREATING_FAILURE_EXIT_CODE
+fi
 
 # Create output directory name in the format:
 #   <year>-<month>-<day>_<hour>-<minute>-<second>_<commit hash>

--- a/ADBench/AzureBatch/runallscript.sh
+++ b/ADBench/AzureBatch/runallscript.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# This script is created for Ubuntu 18.04 for Azure Batch.
+# It should be run by the root user.
+
+# Script constants.
+REPOSITORY_URL="https://github.com/awf/ADBench"
+RESULT_ROOT="$AZ_BATCH_TASK_WORKING_DIR/results"
+INPUT_ROOT="$AZ_BATCH_TASK_WORKING_DIR"
+COMMIT_HASH_FILE_NAME="last_commit.txt" # holds the hash of the last commit,
+                                        # this script has been run for
+
+# Exit codes.
+SUCCESS_EXIT_CODE=0
+UNNECESSARY_RUN_EXIT_CODE=1
+GIT_PROBLEM_EXIT_CODE=2
+DOCKER_PROBLEM_EXIT_CODE=3
+RUNNING_TOOLS_PROBLEM_EXIT_CODE=4
+
+
+
+# Dealing with the problem that seems to be described here:
+#
+#   https://github.com/Microsoft/azure-pipelines-image-generation/issues/185
+#
+# but solution that is provided didn't help in this script. So, the script just
+# deletes locking files.
+rm -f /var/lib/dpkg/lock
+rm -f /var/lib/dpkg/lock-frontend
+
+# Note that all "apt-get" actions are done using this comand prefix:
+#
+#   DEBIAN_FRONTEND="noninteractive"
+#
+# This is necessary because on the node this script is running without tty,
+# so, "apt-get" and tools that it calls can't create a dialog and crash.
+# Giving this environment variable we explicitly say that interactive mode
+# should be turned off.
+
+# Clone the repo.
+cd $AZ_BATCH_TASK_WORKING_DIR
+DEBIAN_FRONTEND="noninteractive" apt-get update \
+    && apt-get install -y git \
+    && git clone $REPOSITORY_URL
+
+if [[ $? -ne 0 ]]
+then
+    echo "Repository cloning is crashed! Stopping the script"
+    exit $GIT_PROBLEM_EXIT_CODE
+fi
+
+cd ADBench
+
+# Check the last commit.
+COMMIT=$(git rev-parse HEAD)
+if [[ $COMMIT == $(cat "$INPUT_ROOT/$COMMIT_HASH_FILE_NAME") ]]
+then
+    echo "Latest commit has been run. Stopping the script"
+
+    # Return non-zero code to prevent result files uploading to the share.
+    exit $UNNECESSARY_RUN_EXIT_CODE
+fi
+
+# Install docker.
+DEBIAN_FRONTEND="noninteractive" apt-get install -y docker.io
+
+# Check that docker is installed.
+if [[ $? -ne 0 ]]
+then
+    echo "Docker installation fail! Stopping the script"
+    exit $DOCKER_PROBLEM_EXIT_CODE
+fi
+
+# Start docker.
+systemctl start docker && sudo systemctl enable docker
+
+# Check that docker is active.
+if [[ ! $(systemctl status docker | grep 'Active: active (running)') ]]
+then
+    echo "Docker is not active! Stopping the script"
+    exit $DOCKER_PROBLEM_EXIT_CODE
+fi
+
+# Prepare docker output directory.
+mkdir tmp
+
+# Create docker image, run all tools and create plots.
+docker build -t adb-docker . \
+    && docker run -v $(pwd)/tmp:/adb/tmp/ adb-docker -r \
+    && docker run -v $(pwd)/tmp:/adb/tmp/ adb-docker -p --save --plotly
+
+if [[ $? -ne 0 ]]
+then
+    echo "Docker running failed! Stopping the script"
+    exit $RUNNING_TOOLS_PROBLEM_EXIT_CODE
+fi
+
+# Create output directory name in the format:
+#   <year>-<month>-<day>_<hour>-<minute>-<second>_<commit hash>
+PLOT_DIR_NAME=$(date -u +"%Y-%m-%d_%H-%M-%S")_$COMMIT
+
+# Create directories from which results will be stored to the blob container.
+mkdir -p "$RESULT_ROOT/$PLOT_DIR_NAME/plotly"
+mkdir "$RESULT_ROOT/$PLOT_DIR_NAME/static"
+
+# Move results to output directory.
+mv tmp/graphs/plotly/Release/* "$RESULT_ROOT/$PLOT_DIR_NAME/plotly"
+mv tmp/graphs/static/Release/* "$RESULT_ROOT/$PLOT_DIR_NAME/static"
+
+# Save hash of the commit this script has been run for.
+echo -en $COMMIT > "$RESULT_ROOT/$COMMIT_HASH_FILE_NAME"
+
+exit $SUCCESS_EXIT_CODE

--- a/ADBench/AzureBatch/runallscript.sh
+++ b/ADBench/AzureBatch/runallscript.sh
@@ -14,9 +14,10 @@ COMMIT_HASH_FILE_NAME="last_commit.txt" # holds the hash of the last commit,
 SUCCESS_EXIT_CODE=0
 UNNECESSARY_RUN_EXIT_CODE=1
 GIT_PROBLEM_EXIT_CODE=2
-DOCKER_PROBLEM_EXIT_CODE=3
-DOCKER_BUILD_PROBLEM_EXIT_CODE=4
-TEST_FAIL_EXIT_CODE=5
+DOCKER_INSTALLATION_PROBLEM_EXIT_CODE=3
+DOCKER_ACTIVATING_PROBLEM_EXIT_CODE=4
+DOCKER_BUILD_PROBLEM_EXIT_CODE=5
+TEST_FAIL_EXIT_CODE=6
 
 
 
@@ -69,7 +70,7 @@ DEBIAN_FRONTEND="noninteractive" apt-get install -y docker.io
 if [[ $? -ne 0 ]]
 then
     echo "Docker installation fail! Stopping the script"
-    exit $DOCKER_PROBLEM_EXIT_CODE
+    exit $DOCKER_INSTALLATION_PROBLEM_EXIT_CODE
 fi
 
 # Start docker.
@@ -79,7 +80,7 @@ systemctl start docker && sudo systemctl enable docker
 if [[ ! $(systemctl status docker | grep 'Active: active (running)') ]]
 then
     echo "Docker is not active! Stopping the script"
-    exit $DOCKER_PROBLEM_EXIT_CODE
+    exit $DOCKER_ACTIVATING_PROBLEM_EXIT_CODE
 fi
 
 # Create docker container.

--- a/ADBench/AzureBatch/runallscript.sh
+++ b/ADBench/AzureBatch/runallscript.sh
@@ -16,6 +16,7 @@ UNNECESSARY_RUN_EXIT_CODE=1
 GIT_PROBLEM_EXIT_CODE=2
 DOCKER_PROBLEM_EXIT_CODE=3
 DOCKER_BUILD_PROBLEM_EXIT_CODE=4
+TEST_FAIL_EXIT_CODE=5
 
 
 
@@ -89,6 +90,25 @@ if [[ $? -ne 0 ]]
 then
     echo "Docker container build fail! Stopping the script"
     exit $DOCKER_BUILD_PROBLEM_EXIT_CODE
+fi
+
+# Some tools/or interpreters (e.g. dotnet, julia) perform some long
+# operations the first time they run, which theoretically can cause some
+# unjustified timeouts. Running test before actual benchmarks would eliminate
+# that problem. Moreover, thus we can be sure that the code in the repository
+# passes the tests.
+
+# Creating directory for test output.
+mkdir testout
+
+# Running CTests.
+docker run -v $(pwd)/testout:/adb/tmp/ adb-docker -t -Q -T test
+
+# Check that tests are passed.
+if [[ $? -ne 0 ]]
+then
+    echo "Tests are failed! Stopping the script"
+    exit $TEST_FAIL_EXIT_CODE
 fi
 
 # Prepare docker output directory.

--- a/ADBench/AzureBatch/schedule.json
+++ b/ADBench/AzureBatch/schedule.json
@@ -1,0 +1,52 @@
+{
+    "id": "runallschedule",
+    "displayName": "Run All Schedule",
+    "schedule": {
+        "startWindow": null,
+        "recurrenceInterval": "PT168H"
+    },
+    "jobSpecification": {
+        "poolInfo": {
+            "poolId": "runallpool"
+        },
+        "constraints": {
+            "maxWallClockTime": null,
+            "maxTaskRetryCount": 0
+        },
+        "jobManagerTask": {
+            "id": "runall",
+            "userIdentity": {
+                "autoUser": {
+                    "scope": "pool",
+                    "elevationLevel": "admin"
+                }
+            },
+            "commandLine": "/bin/sh -c 'bash $AZ_BATCH_APP_PACKAGE_runallscript/runallscript.sh'",
+            "applicationPackageReferences": [
+                {
+                    "applicationId": "runallscript"
+                }
+            ],
+            "resourceFiles": [
+                {
+                    "httpUrl": "<URL of a result blob container>/last_commit.txt",
+                    "filePath": "last_commit.txt"
+                }
+            ],
+            "outputFiles": [
+                {
+                    "destination": {
+                        "container": {
+                            "containerUrl": "<URL of a result blob container with SAS with creating permissions>"
+                        }
+                    },
+                    "filePattern": "results/**/*",
+                    "uploadOptions": {
+                        "uploadCondition": "tasksuccess"
+                    }
+                }
+            ]
+        },
+        "priority": 100
+    }
+}

--- a/docs/AzureBatch.md
+++ b/docs/AzureBatch.md
@@ -18,8 +18,10 @@ If graphs have been already created for the last commit, then the script finishe
 | 0 | Script run successfully and created all graphs |
 | 1 | Graph creation is not needed becuase for the current commit it has been done |
 | 2 | There was a problem with git |
-| 3 | There was a problem with docker |
-| 4 | There was a problem during all tool running |
+| 3 | There was a problem with docker installation |
+| 4 | There was a problem with docker daemon activating |
+| 5 | There was a problem with docker container building |
+| 6 | ADBench test failed |
 
 ### Web viewer
 Special application is used for the process results view. Its source located in the directory `ADBench/ADBenchWebViewer`. This application looks through the blob container, which URL is defined in its `appsettings.json` file and creates HTML pages for result observing. The viewer could be published in Azure as the hosted [Web Application](https://docs.microsoft.com/en-us/azure/app-service/) (see [instruction](https://docs.microsoft.com/en-us/azure/app-service/app-service-web-get-started-dotnet#publish-your-web-app)).

--- a/docs/AzureBatch.md
+++ b/docs/AzureBatch.md
@@ -2,20 +2,20 @@
 
 ## Description
 
-This document describes the all tool running process that is executed once a week and stores results to the Azure Blob container from which they can be observed by the [ADBench Web Viewer](#Web-viewer).
+This document describes the all tool running process that is executed once a week and stores the results to the Azure Blob container from which they can be observed by the [ADBench Web Viewer](#Web-viewer).
 
 ### General info
 The process is designed as an [Azure Batch](https://docs.microsoft.com/en-us/azure/batch/) job that is scheduled weekly. This job starts the script `/ADBench/AzureBatch/runallscript.sh` on the pool node. This script clones the repository from GitHub, creates a Docker container, and runs all tools. After run completion the script runs graph creating and then stores the result plots to the output directory from which they are uploaded to the [Azure Storage](https://docs.microsoft.com/en-us/azure/storage/).
 
 ### Recalculating check
-If graphs have been already created for the last commit, then the script finishes and does nothing. To check that the last commit has been handled, the process stores its hash to the file called `last_commit.txt` located in the blob container root. Before the script starting the job downloads this file to the pool node. The script compares the file content with the latest repository master branch commit hash. In case of equality it finishes. Exit code the script returns in such a case is not zero because zero exit code is a signal to the job to upload the result graphs to the storage. In case of hash difference the script writes the current handled comit hash to the file `last_commit.txt`, and then the job uploads this file to the blob container.
+If graphs have been already created for the last commit, then the script finishes and does nothing. To check that the last commit has been handled, the process stores its hash to the file called `last_commit.txt` located in the blob container root. Before the script starting, the job downloads this file to the pool node. The script compares the file content with the latest repository master branch commit hash. In case of equality it finishes. Exit code the script returns in such a case is not zero because zero exit code is a signal to the job to upload the result graphs to the storage. In case of hash difference the script writes the current handled commit hash to the file `last_commit.txt`, and then the job uploads this file to the blob container.
 
 ### The script
 `/ADBench/AzureBatch/runallscript.sh` is a bash script that is designed for *Ubuntu 18.04*. It has descriptive comments, so you can find more information about its behaviour in them. The script returns the following exit codes:
 
 | Exit code | The case when it is returned |
 | -- | -- |
-| 0 | Script run successfully and created all graphs |
+| 0 | Script ran successfully and created all graphs |
 | 1 | Graph creation is not needed becuase for the current commit it has been done |
 | 2 | Git problem |
 | 3 | Docker installation problem |
@@ -26,7 +26,7 @@ If graphs have been already created for the last commit, then the script finishe
 | 8 | Graph creation failure |
 
 ### Web viewer
-Special application is used for the process result browse. Its source is located in the directory `/ADBench/ADBenchWebViewer`. This application looks through the blob container, which URL is defined in its `appsettings.json` file, and creates HTML pages for the result observing. The viewer could be published in Azure as the hosted [Web Application](https://docs.microsoft.com/en-us/azure/app-service/) (see [instruction](https://docs.microsoft.com/en-us/azure/app-service/app-service-web-get-started-dotnet#publish-your-web-app)).
+The special application is used for the process result browsing. Its source is located in the directory `/ADBench/ADBenchWebViewer`. This application looks through the blob container, which URL is defined in its `appsettings.json` file, and creates HTML pages for the result observing. The viewer could be published in Azure as a hosted [Web Application](https://docs.microsoft.com/en-us/azure/app-service/) (see [instruction](https://docs.microsoft.com/en-us/azure/app-service/app-service-web-get-started-dotnet#publish-your-web-app)).
 
 ## Creating a new Azure Batch
 
@@ -47,4 +47,4 @@ If you want to deploy a new Azure Batch Job Schedule, that will execute the run 
     | jobSpecification.resourceFiles[0].httpUrl | URL of the file `last_commit.txt` in the blob container root |
     | jobSpecification.outputFiles[0].destination.container.containerUrl | URL of the blob container |
 
-6. If you want to see the results of the new process in the ADBench Web Viewer, set the value of the property `blobContainerUrl` in a JSON file `/ADBenchWebViewer/appsettings.json` to the URL of the blob container created in the step 1. Then web app will show info from your new container.
+6. If you want to see the results of the new process in the ADBench Web Viewer, set the value of the property `blobContainerUrl` in a JSON file `/ADBenchWebViewer/appsettings.json` to the URL of the blob container created in the step 1. Then the web app will show info from your new container.

--- a/docs/AzureBatch.md
+++ b/docs/AzureBatch.md
@@ -2,16 +2,16 @@
 
 ## Description
 
-This document describes the all tool running process that is executed once a week and stores the results to the Azure Blob container from which they can be observed by the [ADBench Web Viewer](#Web-viewer).
+This document describes the all tool running process that is executed once a week and stores the results to the Azure Blob container from which they can be observed by the [ADBench Web Viewer](#Web-viewer). All paths in this document are specified relative to the repository root.
 
 ### General info
-The process is designed as an [Azure Batch](https://docs.microsoft.com/en-us/azure/batch/) job that is scheduled weekly. This job starts the script `/ADBench/AzureBatch/runallscript.sh` on the pool node. This script clones the repository from GitHub, creates a Docker container, and runs all tools. After run completion the script runs graph creating and then stores the result plots to the output directory from which they are uploaded to the [Azure Storage](https://docs.microsoft.com/en-us/azure/storage/).
+The process is designed as an [Azure Batch](https://docs.microsoft.com/en-us/azure/batch/) job that is scheduled weekly. This job starts the script `ADBench/AzureBatch/runallscript.sh` on the pool node. This script clones the repository from GitHub, creates a Docker container, and runs all tools. After run completion the script runs graph creating and then stores the result plots to the output directory from which they are uploaded to the [Azure Storage](https://docs.microsoft.com/en-us/azure/storage/).
 
 ### Recalculating check
 If graphs have been already created for the last commit, then the script finishes and does nothing. To check that the last commit has been handled, the process stores its hash to the file called `last_commit.txt` located in the blob container root. Before the script starting, the job downloads this file to the pool node. The script compares the file content with the latest repository master branch commit hash. In case of equality it finishes. Exit code the script returns in such a case is not zero because zero exit code is a signal to the job to upload the result graphs to the storage. In case of hash difference the script writes the current handled commit hash to the file `last_commit.txt`, and then the job uploads this file to the blob container.
 
 ### The script
-`/ADBench/AzureBatch/runallscript.sh` is a bash script that is designed for *Ubuntu 18.04*. It has descriptive comments, so you can find more information about its behaviour in them. The script returns the following exit codes:
+`ADBench/AzureBatch/runallscript.sh` is a bash script that is designed for *Ubuntu 18.04*. It has descriptive comments, so you can find more information about its behaviour in them. The script returns the following exit codes:
 
 | Exit code | The case when it is returned |
 | -- | -- |
@@ -26,7 +26,7 @@ If graphs have been already created for the last commit, then the script finishe
 | 8 | Graph creation failure |
 
 ### Web viewer
-The special application is used for the process result browsing. Its source is located in the directory `/ADBench/ADBenchWebViewer`. This application looks through the blob container, which URL is defined in its `appsettings.json` file, and creates HTML pages for the result observing. The viewer could be published in Azure as a hosted [Web Application](https://docs.microsoft.com/en-us/azure/app-service/) (see [instruction](https://docs.microsoft.com/en-us/azure/app-service/app-service-web-get-started-dotnet#publish-your-web-app)).
+The special application is used for the process result browsing. Its source is located in the directory `ADBench/ADBenchWebViewer`. This application looks through the blob container, which URL is defined in its `appsettings.json` file, and creates HTML pages for the result observing. The viewer could be published in Azure as a hosted [Web Application](https://docs.microsoft.com/en-us/azure/app-service/) (see [instruction](https://docs.microsoft.com/en-us/azure/app-service/app-service-web-get-started-dotnet#publish-your-web-app)).
 
 ## Creating a new Azure Batch
 
@@ -39,12 +39,12 @@ If you want to deploy a new Azure Batch Job Schedule, that will execute the run 
     $TargetDedicatedNodes = (max($PendingTasks.GetSample(TimeInterval_Minute * 5)) > 0.0) ? 1 : 0
     ```
     Thus, pool will create a node if there was a pending task in the last 5 minutes and will remove node otherwise.
-4. Create an [application package](https://docs.microsoft.com/en-us/azure/batch/batch-application-packages) named _runallscript_ with version _1_ contains a zip with the file `/ADBench/AzureBatch/runallscript.sh`. Set its default version to _1_.
-5. Create a [job schedule](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics#scheduled-jobs) using the JSON file `/ADBench/AzureBatch/schedule.json` (you can use both [REST API](https://docs.microsoft.com/en-us/rest/api/batchservice/jobschedule/add) or [Azure Portal](https://portal.azure.com) for this), setting these missed properties with respective values (use info of the blob container created in the step 1):
+4. Create an [application package](https://docs.microsoft.com/en-us/azure/batch/batch-application-packages) named _runallscript_ with version _1_ contains a zip with the file `ADBench/AzureBatch/runallscript.sh`. Set its default version to _1_.
+5. Create a [job schedule](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics#scheduled-jobs) using the JSON file `ADBench/AzureBatch/schedule.json` (you can use both [REST API](https://docs.microsoft.com/en-us/rest/api/batchservice/jobschedule/add) or [Azure Portal](https://portal.azure.com) for this), setting these missed properties with respective values (use info of the blob container created in the step 1):
 
     | Property | Value description |
     | -- | -- |
     | jobSpecification.resourceFiles[0].httpUrl | URL of the file `last_commit.txt` in the blob container root |
     | jobSpecification.outputFiles[0].destination.container.containerUrl | URL of the blob container |
 
-6. If you want to see the results of the new process in the ADBench Web Viewer, set the value of the property `blobContainerUrl` in a JSON file `/ADBenchWebViewer/appsettings.json` to the URL of the blob container created in the step 1. Then the web app will show info from your new container.
+6. If you want to see the results of the new process in the ADBench Web Viewer, set the value of the property `blobContainerUrl` in a JSON file `ADBench/ADBenchWebViewer/ADBenchWebViewer/appsettings.json` to the URL of the blob container created in the step 1. Then the web app will show info from your new container.

--- a/docs/AzureBatch.md
+++ b/docs/AzureBatch.md
@@ -1,0 +1,40 @@
+# Azure Batch All Tool Running
+
+## Description
+
+This document describes all tool running process that is executed once a week and stores results to the Azure Blob container from which they can be observed by the [ADBench Web Viewer](#Web-viewer).
+
+### General info
+The process is designed as an [Azure Batch](https://docs.microsoft.com/en-us/azure/batch/) job that is scheduled weekly. This job starts the script `/ADBench/AzureBatch/runallscript.sh` on the pool node. This script clones the repository from GitHub, creates a Docker container, and runs all tools. After run completion the script runs graph creating and then stores result plots to the output directory from which they are uploaded to the [Azure Storage](https://docs.microsoft.com/en-us/azure/storage/).
+
+### Recalculating check
+If graphs have been already created for the last commit, then the script finishes and does nothing. To check that the last commit has been handled, the process stores its hash to the file called `last_commit.txt` located in the blob container root. Before the script starting the job downloads this file to the pool node. The script compares the file content with the latest repository master branch commit hash. In case of equality it finishes. Exit code the script returns in such a case is not zero because zero exit code is a signal to the job to upload result graphs to the storage. In case of hash difference the script write the current handled comit hash to the file and then the job uploads this file to the blob container.
+
+### The script
+`runallscript.sh` is a bash script that is designed for *Ubuntu 18.04*. It has descriptive comments, so, you can find more information about its behaviour in them. The script returns the following exit codes:
+
+| Exit code | The case when it is returned |
+| -- | -- |
+| 0 | Script run successfully and created all graphs |
+| 1 | Graph creation is not needed becuase for the current commit it has been done |
+| 2 | There was a problem with git |
+| 3 | There was a problem with docker |
+| 4 | There was a problem during all tool running |
+
+### Web viewer
+Special application is used for the process results view. Its source located in the directory `ADBench/ADBenchWebViewer`. This application looks through the blob container, which URL is defined in its `appsettings.json` file and creates HTML pages for result observing. The viewer could be published in Azure as the hosted [Web Application](https://docs.microsoft.com/en-us/azure/app-service/) (see [instruction](https://docs.microsoft.com/en-us/azure/app-service/app-service-web-get-started-dotnet#publish-your-web-app)).
+
+## Creating a new Azure Batch
+
+If you want to create a new Azure Batch that will do weekly run all process, do the following steps:
+
+1. Create an [Azure Storage Account](https://docs.microsoft.com/en-us/azure/storage/common/storage-quickstart-create-account?tabs=azure-portal). Set up a blob container for the future storing run process results. Create an empty file `last_commit.txt` in the container root.
+2. Create an [Azure Batch Account](https://docs.microsoft.com/en-us/azure/batch/batch-account-create-portal).
+3. Create a [pool](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics#pool). Chose *Ubuntu 18.04* as an image. As far as the process requires only one node, you can use this [autoscale formula](https://docs.microsoft.com/en-us/azure/batch/batch-automatic-scaling) for the pool:
+    ```
+    $TargetDedicatedNodes = (max($PendingTasks.GetSample(TimeInterval_Minute * 5)) > 0.0) ? 1 : 0
+    ```
+    Thus, pool will create a node if there was a pending task in the last 5 minutes and will remove node if there wasn't.
+4. Create an [application package](https://docs.microsoft.com/en-us/azure/batch/batch-application-packages) named _runallscript_ with version _1_ contains a zip with the file `runallscript.sh`. Set its default version to _1_.
+5. Create a [job schedule](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics#scheduled-jobs) using the JSON file `schedule.json` (you can use both [REST API](https://docs.microsoft.com/en-us/rest/api/batchservice/jobschedule/add) or [Azure Portal](https://portal.azure.com) for this). Set properties `jobSpecification.resourceFiles` and `jobSpecification.outputFiles` with respective info about the blob container you created in the step 1.
+6. If you want to see results from the new process in the ADBench Web Viewer, set the value of the property `blobContainerUrl` in a JSON file `ADBenchWebViewer/appsettings.json` to the URL of the blob container you created in the step 1. Then web app will show info from your new container.

--- a/docs/AzureBatch.md
+++ b/docs/AzureBatch.md
@@ -2,43 +2,49 @@
 
 ## Description
 
-This document describes all tool running process that is executed once a week and stores results to the Azure Blob container from which they can be observed by the [ADBench Web Viewer](#Web-viewer).
+This document describes the all tool running process that is executed once a week and stores results to the Azure Blob container from which they can be observed by the [ADBench Web Viewer](#Web-viewer).
 
 ### General info
-The process is designed as an [Azure Batch](https://docs.microsoft.com/en-us/azure/batch/) job that is scheduled weekly. This job starts the script `/ADBench/AzureBatch/runallscript.sh` on the pool node. This script clones the repository from GitHub, creates a Docker container, and runs all tools. After run completion the script runs graph creating and then stores result plots to the output directory from which they are uploaded to the [Azure Storage](https://docs.microsoft.com/en-us/azure/storage/).
+The process is designed as an [Azure Batch](https://docs.microsoft.com/en-us/azure/batch/) job that is scheduled weekly. This job starts the script `/ADBench/AzureBatch/runallscript.sh` on the pool node. This script clones the repository from GitHub, creates a Docker container, and runs all tools. After run completion the script runs graph creating and then stores the result plots to the output directory from which they are uploaded to the [Azure Storage](https://docs.microsoft.com/en-us/azure/storage/).
 
 ### Recalculating check
-If graphs have been already created for the last commit, then the script finishes and does nothing. To check that the last commit has been handled, the process stores its hash to the file called `last_commit.txt` located in the blob container root. Before the script starting the job downloads this file to the pool node. The script compares the file content with the latest repository master branch commit hash. In case of equality it finishes. Exit code the script returns in such a case is not zero because zero exit code is a signal to the job to upload result graphs to the storage. In case of hash difference the script write the current handled comit hash to the file and then the job uploads this file to the blob container.
+If graphs have been already created for the last commit, then the script finishes and does nothing. To check that the last commit has been handled, the process stores its hash to the file called `last_commit.txt` located in the blob container root. Before the script starting the job downloads this file to the pool node. The script compares the file content with the latest repository master branch commit hash. In case of equality it finishes. Exit code the script returns in such a case is not zero because zero exit code is a signal to the job to upload the result graphs to the storage. In case of hash difference the script writes the current handled comit hash to the file `last_commit.txt`, and then the job uploads this file to the blob container.
 
 ### The script
-`runallscript.sh` is a bash script that is designed for *Ubuntu 18.04*. It has descriptive comments, so, you can find more information about its behaviour in them. The script returns the following exit codes:
+`/ADBench/AzureBatch/runallscript.sh` is a bash script that is designed for *Ubuntu 18.04*. It has descriptive comments, so you can find more information about its behaviour in them. The script returns the following exit codes:
 
 | Exit code | The case when it is returned |
 | -- | -- |
 | 0 | Script run successfully and created all graphs |
 | 1 | Graph creation is not needed becuase for the current commit it has been done |
-| 2 | There was a problem with git |
-| 3 | There was a problem with docker installation |
-| 4 | There was a problem with docker daemon activating |
-| 5 | There was a problem with docker container building |
-| 6 | ADBench test failed |
+| 2 | Git problem |
+| 3 | Docker installation problem |
+| 4 | Docker daemon activating problem |
+| 5 | Docker container building problem |
+| 6 | ADBench tests failure |
 | 7 | Tool running failure |
-| 8 | Plot creating failure |
+| 8 | Graph creation failure |
 
 ### Web viewer
-Special application is used for the process results view. Its source located in the directory `ADBench/ADBenchWebViewer`. This application looks through the blob container, which URL is defined in its `appsettings.json` file and creates HTML pages for result observing. The viewer could be published in Azure as the hosted [Web Application](https://docs.microsoft.com/en-us/azure/app-service/) (see [instruction](https://docs.microsoft.com/en-us/azure/app-service/app-service-web-get-started-dotnet#publish-your-web-app)).
+Special application is used for the process result browse. Its source is located in the directory `/ADBench/ADBenchWebViewer`. This application looks through the blob container, which URL is defined in its `appsettings.json` file, and creates HTML pages for the result observing. The viewer could be published in Azure as the hosted [Web Application](https://docs.microsoft.com/en-us/azure/app-service/) (see [instruction](https://docs.microsoft.com/en-us/azure/app-service/app-service-web-get-started-dotnet#publish-your-web-app)).
 
 ## Creating a new Azure Batch
 
-If you want to create a new Azure Batch that will do weekly run all process, do the following steps:
+If you want to deploy a new Azure Batch Job Schedule, that will execute the run all process weekly, do the following steps:
 
-1. Create an [Azure Storage Account](https://docs.microsoft.com/en-us/azure/storage/common/storage-quickstart-create-account?tabs=azure-portal). Set up a blob container for the future storing run process results. Create an empty file `last_commit.txt` in the container root.
+1. Create an [Azure Storage Account](https://docs.microsoft.com/en-us/azure/storage/common/storage-quickstart-create-account?tabs=azure-portal). Set up a blob container in which the run all process will store the results. Create an empty file `last_commit.txt` in the container root.
 2. Create an [Azure Batch Account](https://docs.microsoft.com/en-us/azure/batch/batch-account-create-portal).
 3. Create a [pool](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics#pool). Chose *Ubuntu 18.04* as an image. As far as the process requires only one node, you can use this [autoscale formula](https://docs.microsoft.com/en-us/azure/batch/batch-automatic-scaling) for the pool:
     ```
     $TargetDedicatedNodes = (max($PendingTasks.GetSample(TimeInterval_Minute * 5)) > 0.0) ? 1 : 0
     ```
-    Thus, pool will create a node if there was a pending task in the last 5 minutes and will remove node if there wasn't.
-4. Create an [application package](https://docs.microsoft.com/en-us/azure/batch/batch-application-packages) named _runallscript_ with version _1_ contains a zip with the file `runallscript.sh`. Set its default version to _1_.
-5. Create a [job schedule](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics#scheduled-jobs) using the JSON file `schedule.json` (you can use both [REST API](https://docs.microsoft.com/en-us/rest/api/batchservice/jobschedule/add) or [Azure Portal](https://portal.azure.com) for this). Set properties `jobSpecification.resourceFiles` and `jobSpecification.outputFiles` with respective info about the blob container you created in the step 1.
-6. If you want to see results from the new process in the ADBench Web Viewer, set the value of the property `blobContainerUrl` in a JSON file `ADBenchWebViewer/appsettings.json` to the URL of the blob container you created in the step 1. Then web app will show info from your new container.
+    Thus, pool will create a node if there was a pending task in the last 5 minutes and will remove node otherwise.
+4. Create an [application package](https://docs.microsoft.com/en-us/azure/batch/batch-application-packages) named _runallscript_ with version _1_ contains a zip with the file `/ADBench/AzureBatch/runallscript.sh`. Set its default version to _1_.
+5. Create a [job schedule](https://docs.microsoft.com/en-us/azure/batch/batch-api-basics#scheduled-jobs) using the JSON file `/ADBench/AzureBatch/schedule.json` (you can use both [REST API](https://docs.microsoft.com/en-us/rest/api/batchservice/jobschedule/add) or [Azure Portal](https://portal.azure.com) for this), setting these missed properties with respective values (use info of the blob container created in the step 1):
+
+    | Property | Value description |
+    | -- | -- |
+    | jobSpecification.resourceFiles[0].httpUrl | URL of the file `last_commit.txt` in the blob container root |
+    | jobSpecification.outputFiles[0].destination.container.containerUrl | URL of the blob container |
+
+6. If you want to see the results of the new process in the ADBench Web Viewer, set the value of the property `blobContainerUrl` in a JSON file `/ADBenchWebViewer/appsettings.json` to the URL of the blob container created in the step 1. Then web app will show info from your new container.

--- a/docs/AzureBatch.md
+++ b/docs/AzureBatch.md
@@ -22,6 +22,8 @@ If graphs have been already created for the last commit, then the script finishe
 | 4 | There was a problem with docker daemon activating |
 | 5 | There was a problem with docker container building |
 | 6 | ADBench test failed |
+| 7 | Tool running failure |
+| 8 | Plot creating failure |
 
 ### Web viewer
 Special application is used for the process results view. Its source located in the directory `ADBench/ADBenchWebViewer`. This application looks through the blob container, which URL is defined in its `appsettings.json` file and creates HTML pages for result observing. The viewer could be published in Azure as the hosted [Web Application](https://docs.microsoft.com/en-us/azure/app-service/) (see [instruction](https://docs.microsoft.com/en-us/azure/app-service/app-service-web-get-started-dotnet#publish-your-web-app)).


### PR DESCRIPTION
Azure Batch Job Schedule for weekly running all tools and creating graphs with storing them to the blob container, that can be observed by the [ADBench Web Viewer](https://github.com/awf/ADBench/pull/144), is created in [this](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/0f64a630-b912-4501-ad57-262a9e12637c/resourceGroups/ADBench/providers/Microsoft.Batch/batchAccounts/adbenchrunbatch/accountOverview) Azure Batch Account. This PR adds info about this job schedule.

Adding files:

1. Bash script that is run in a pool node.
2. JSON file that describes job schedule with missed blob container URL. It can be used for creating a new Azure Batch Job Schedule
3. Documentation that describes the script and the weekly run process and also contains instructions about creating a new job schedule.

**Note**: this PR is partially connected with #144 (by the documentation), so, it should be merged after that PR will have completed.

**Possible improving**: maybe we need to increase timeout for this kind of tool run, e.g. up to 10 or even 15 minutes