### PR TITLE
Dmkats/stablelse

### DIFF
--- a/src/dotnet/modules/DiffSharpModule/gmm.fs
+++ b/src/dotnet/modules/DiffSharpModule/gmm.fs
@@ -48,11 +48,12 @@ let gmmObjective (alphas: DV) (means: DV[]) (icf: DV[]) (x: DM) (wishartGamma: f
 
     let slse = x.GetRows ()
                 |> Seq.sumBy (fun xi ->
-                    let term = Array.map2 (fun qAndSum alphaAndMeans ->
-                        let q, sumQ = qAndSum
-                        let alpha, meansk = alphaAndMeans
-                        -0.5 * (DV.l2normSq (q * (xi - meansk))) + alpha + sumQ) qsAndSums alphasAndMeans
-                    logsumexp_DArray term)
+                    logsumexp_DArray <| Array.map2
+                        (fun qAndSum alphaAndMeans ->
+                            let q, sumQ = qAndSum
+                            let alpha, meansk = alphaAndMeans
+                            -0.5 * (DV.l2normSq (q * (xi - meansk))) + alpha + sumQ
+                        ) qsAndSums alphasAndMeans)
 
     constant + slse  - float(n) * logsumexp alphas + logWishartPrior qsAndSums wishartGamma wishartM d
 

--- a/src/julia/modules/Zygote/ZygoteGMM.jl
+++ b/src/julia/modules/Zygote/ZygoteGMM.jl
@@ -112,12 +112,9 @@ function gmm_objective(alphas, means, Qs, x, wishart::Wishart)
 
     slse = 0.
     for ix=1:n
-        formula(ik) = -0.5 * sum(abs2, Qs[:, :, ik] * (x[:,ix] .- means[:, ik]))
-        sumexp = 0.
-        for ik=1:k
-            sumexp += exp(formula(ik) + alphas[ik] + sum_qs[ik])
-        end
-        slse += log(sumexp)
+        formula(ik) = -0.5 * sum(abs2, Qs[:, :, ik] * (x[:,ix] .- means[:, ik])) + alphas[ik] + sum_qs[ik]
+        terms = map(formula, 1:k)
+        slse += logsumexp(terms)
     end
 
     CONSTANT + slse - n * logsumexp(alphas) + log_wishart_prior(wishart, sum_qs, Qs, k)


### PR DESCRIPTION
Numerically stable implementation of LogSumExp in GMM for Zygote and DiffSharp modules. Fixes incorrect results when `d = 64`.

<img width="864" alt="GMM (1k)  Jacobian  - Release Graph" src="https://user-images.githubusercontent.com/24294192/68476842-eca8cc00-023c-11ea-8e60-6ca40ceceafd.png">

<img width="864" alt="GMM (10k)  Jacobian  - Release Graph" src="https://user-images.githubusercontent.com/24294192/68483056-dce4b400-024b-11ea-9a65-925171d16120.png">

Zygote times became worse. In fact, I had to increase timeout to get a result on d64k5, 10k points.
But, the result became correct which didn't use to be the case.