### PR TITLE
Timeout for Azure Batch is doubled

### DIFF
--- a/ADBench/AzureBatch/runallscript.sh
+++ b/ADBench/AzureBatch/runallscript.sh
@@ -118,7 +118,7 @@ fi
 mkdir tmp
 
 # Run all tools.
-docker run -v $(pwd)/tmp:/adb/tmp/ adb-docker -r
+docker run -v $(pwd)/tmp:/adb/tmp/ adb-docker -r "-timeout 600"
 
 # Check tool running.
 # Note: run-all.ps1 script returns "8" in case of non-fatal errors.


### PR DESCRIPTION
**Note**: the new version of the script has already been added to the [Azure Batch](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/0f64a630-b912-4501-ad57-262a9e12637c/resourceGroups/ADBench/providers/Microsoft.Batch/batchAccounts/adbenchrunbatch/accountOverview)