### PR TITLE
Using Sort-Object

### DIFF
--- a/ADBench/run-all.ps1
+++ b/ADBench/run-all.ps1
@@ -103,10 +103,10 @@ param(# Which build to test.
 
 # Sort array parameters define test sizes ascending
 function sort_size_parameters() {
-    $script:gmm_d_vals = $script:gmm_d_vals | sort
-    $script:gmm_k_vals = $script:gmm_k_vals | sort
-    $script:lstm_l_vals = $script:lstm_l_vals | sort
-    $script:lstm_c_vals = $script:lstm_c_vals | sort
+    $script:gmm_d_vals = $script:gmm_d_vals | Sort-Object
+    $script:gmm_k_vals = $script:gmm_k_vals | Sort-Object
+    $script:lstm_l_vals = $script:lstm_l_vals | Sort-Object
+    $script:lstm_c_vals = $script:lstm_c_vals | Sort-Object
 }
 
 # Assert function


### PR DESCRIPTION
This PR is done due to some bug in the current array parameter sorting.

A `sort` alias for the comandlet `Sort-Object` was used in the PowerShell code. It works fine in Windows, but doesn't in Linux, because there is an utility called `sort` in Linux. That's why in _PowerShell Core_ there is no alias `sort` for `Sort-Object`, so calling `sort` the script uses Linux utility `sort`, that sorting values alphabetically by default. It leads to some strange behaviour, for example the script calculates GMM for `d = 10` before `d = 2`. So, now the alias using is removed.