### PR TITLE
Weekly run all process script changes

### DIFF
--- a/ADBench/AzureBatch/runallscript.sh
+++ b/ADBench/AzureBatch/runallscript.sh
@@ -118,7 +118,7 @@ fi
 mkdir tmp
 
 # Run all tools.
-docker run -v $(pwd)/tmp:/adb/tmp/ adb-docker -r "-timeout 600"
+docker run -v $(pwd)/tmp:/adb/tmp/ adb-docker -r "-timeout 900"
 
 # Check tool running.
 # Note: run-all.ps1 script returns "8" in case of non-fatal errors.

--- a/ADBench/AzureBatch/runallscript.sh
+++ b/ADBench/AzureBatch/runallscript.sh
@@ -118,7 +118,7 @@ fi
 mkdir tmp
 
 # Run all tools.
-docker run -v $(pwd)/tmp:/adb/tmp/ adb-docker -r "-timeout 900"
+docker run -v $(pwd)/tmp:/adb/tmp/ adb-docker -r "-timeout 900 -ba_max_n 10 -hand_max_n 10"
 
 # Check tool running.
 # Note: run-all.ps1 script returns "8" in case of non-fatal errors.


### PR DESCRIPTION
1. Timeout is increased up to 900 seconds.
2. Additional tests for BA and Hand (now a numer of the tests is 10).

**Note**: the new version of the script has already been uploaded to the [Azure Batch](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/0f64a630-b912-4501-ad57-262a9e12637c/resourceGroups/ADBench/providers/Microsoft.Batch/batchAccounts/adbenchrunbatch/accountOverview)