### PR TITLE
Say "timed out" instead of "terminated"

### DIFF
--- a/ADBench/plot_graphs.py
+++ b/ADBench/plot_graphs.py
@@ -24,7 +24,7 @@ TIMES_SUBSTRING = "_times_"
 CORRECTNESS_SUBSTRING = "_correctness_"
 
 VIOLATION_LABEL = "Wrong calculation result"
-ALL_TERMINATED_SUFFIX = " (all crashed/terminated)"
+ALL_TERMINATED_SUFFIX = " (all crashed/timed out)"
 
 figure_size = (9, 6) if do_plotly else (12, 8)
 fig_dpi = 96


### PR DESCRIPTION
because the former is more precise