### PR TITLE
Accelerating PyTorch GMM objective

### DIFF
--- a/src/python/modules/PyTorch/gmm_objective.py
+++ b/src/python/modules/PyTorch/gmm_objective.py
@@ -58,7 +58,7 @@ def constructL(d, icf):
 
 def Qtimesx(Qdiag, L, x):
 
-    f = torch.einsum('rbq,prq->prb', L, x)
+    f = torch.einsum('ijk,mik->mij', L, x)
     return Qdiag * x + f
 
 

--- a/src/python/modules/PyTorch/gmm_objective.py
+++ b/src/python/modules/PyTorch/gmm_objective.py
@@ -9,6 +9,14 @@ def logsumexp(x):
     return torch.log(sum(emx)) + mx
 
 
+def logsumexpvec(x):
+    '''The same as "logsumexp" but calculates result for each row separately.'''
+
+    mx = torch.max(x, 1).values
+    lset = torch.logsumexp(torch.t(x) - mx, 0)
+    return torch.t(lset + mx)
+
+
 def log_gamma_distrib(a, p):
     return scipy_special.multigammaln(a, p)
 
@@ -20,13 +28,15 @@ def sqsum(x):
 def log_wishart_prior(p, wishart_gamma, wishart_m, sum_qs, Qdiags, icf):
     n = p + wishart_m + 1
     k = icf.shape[0]
-    out = 0
-    for ik in range(k):
-        frobenius = sqsum(Qdiags[ik, :]) + sqsum(icf[ik, p:])
-        out = out + 0.5 * wishart_gamma * wishart_gamma * \
-            frobenius - wishart_m * sum_qs[ik]
-    C = n * p * (math.log(wishart_gamma) - 0.5 * math.log(2)) - log_gamma_distrib(0.5 * n, p)
-    return out - k * C
+
+    out = torch.sum(
+        0.5 * wishart_gamma * wishart_gamma *
+        (torch.sum(Qdiags ** 2, dim = 1) + torch.sum(icf[:,p:] ** 2, dim = 1)) -
+        wishart_m * sum_qs
+    )
+
+    C = n * p * (math.log(wishart_gamma / math.sqrt(2)))
+    return out - k * (C - log_gamma_distrib(0.5 * n, p))
 
 
 def constructL(d, icf):
@@ -34,38 +44,38 @@ def constructL(d, icf):
 
     def make_L_col(i):
         nelems = d - i - 1
-        col = torch.cat([torch.zeros(i + 1, dtype=torch.float64), icf[constructL.Lparamidx:(constructL.Lparamidx + nelems)]])
+        col = torch.cat([
+            torch.zeros(i + 1, dtype = torch.float64),
+            icf[constructL.Lparamidx:(constructL.Lparamidx + nelems)]
+        ])
+
         constructL.Lparamidx += nelems
         return col
+
     columns = [make_L_col(i) for i in range(d)]
     return torch.stack(columns, -1)
 
 
 def Qtimesx(Qdiag, L, x):
-    res = Qdiag * x
-    for i in range(L.shape[0]):
-        res = res + L[:, i] * x[i]
-    return res
+
+    f = torch.einsum('rbq,prq->prb', L, x)
+    return Qdiag * x + f
 
 
 def gmm_objective(alphas, means, icf, x, wishart_gamma, wishart_m):
-    def inner_term(ix, ik):
-        xcentered = x[ix, :] - means[ik, :]
-        Lxcentered = Qtimesx(Qdiags[ik, :], Ls[ik, :, :], xcentered)
-        sqsum_Lxcentered = sqsum(Lxcentered)
-        return alphas[ik] + sum_qs[ik] - 0.5 * sqsum_Lxcentered
-
     n = x.shape[0]
     d = x.shape[1]
-    k = alphas.size()[0]
 
-    Qdiags = torch.stack([(torch.exp(icf[ik, :d])) for ik in range(k)])
-    sum_qs = torch.stack([(torch.sum(icf[ik, :d])) for ik in range(k)])
+    Qdiags = torch.exp(icf[:, :d])
+    sum_qs = torch.sum(icf[:, :d], 1)
     Ls = torch.stack([constructL(d, curr_icf) for curr_icf in icf])
-    slse = 0
-    for ix in range(n):
-        lse = torch.stack([inner_term(ix, ik) for ik in range(k)])
-        slse = slse + logsumexp(lse)
+    
+    xcentered = torch.stack(tuple( x[i] - means for i in range(n) ))
+    Lxcentered = Qtimesx(Qdiags, Ls, xcentered)
+    sqsum_Lxcentered = torch.sum(Lxcentered ** 2, 2)
+    inner_term = alphas + sum_qs - 0.5 * sqsum_Lxcentered
+    lse = logsumexpvec(inner_term)
+    slse = torch.sum(lse)
 
     CONSTANT = -n * d * 0.5 * math.log(2 * math.pi)
     return CONSTANT + slse - n * logsumexp(alphas) \


### PR DESCRIPTION
GMM objective for PyTorch is refactored with accelerating.

**Note**: plots for the tools other than `Tensorflow`, `Manual` and `PyTorch` can be wrong.

# Examples of the old graphs
<img width="864" alt="GMM (1k)  Jacobian  - Release Graph" src="https://user-images.githubusercontent.com/40039815/71281274-8f8d5380-236e-11ea-8874-525183105091.png">
<img width="864" alt="GMM (10k)  Jacobian  - Release Graph" src="https://user-images.githubusercontent.com/40039815/71281281-93b97100-236e-11ea-9db5-c2a1e34ff1e8.png">

# Examples of the new graphs
<img width="864" alt="GMM (1k)  Jacobian  - Release Graph" src="https://user-images.githubusercontent.com/40039815/71281319-a7fd6e00-236e-11ea-9a65-2489c923458d.png">
<img width="864" alt="GMM (10k)  Jacobian  - Release Graph" src="https://user-images.githubusercontent.com/40039815/71281329-acc22200-236e-11ea-98bc-f01d73bdac52.png">
