### PR TITLE
Dmkats/buildfix

### DIFF
--- a/adobuilds/pr-win.yml
+++ b/adobuilds/pr-win.yml
@@ -21,6 +21,14 @@ jobs:
         architecture: x64
 
     - script: |
+        python -m pip install --upgrade pip
+      displayName: Upgrade pip
+
+    - script: |
+        python -m pip install pip setuptools>=41.0.0
+      displayName: Install setuptools
+
+    - script: |
         choco install --limit-output julia
       displayName: Install Julia
 

--- a/adobuilds/pr-win.yml
+++ b/adobuilds/pr-win.yml
@@ -15,6 +15,7 @@ jobs:
 
   steps:
     - task: UsePythonVersion@0
+      name: UsePython
       inputs:
         versionSpec: 3.7
         addToPath: true
@@ -40,7 +41,7 @@ jobs:
     - task: CMake@1
       inputs:
         workingDirectory: '$(Build.SourcesDirectory)/build'
-        cmakeArgs: '-DCMAKE_BUILD_TYPE=release ..'
+        cmakeArgs: '-DPython3_EXECUTABLE=$(UsePython.pythonLocation)/python.exe -DCMAKE_BUILD_TYPE=release ..'
       displayName: Configure
 
     - task: CMake@1


### PR DESCRIPTION
Fixes #176 
Build: https://msrcambridge.visualstudio.com/Knossos/_build/results?buildId=48485

The problem was that cmake's find_package found Python 3.8, instead of the default 3.7.
Python 3.8 is not yet supported by all pip packages.